### PR TITLE
Add CI to push multi-platform images

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,43 @@
+name: Build and Push Multi-Platform Image to Quay
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to Quay
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache for Docker's buildx
+        uses: actions/cache@v3
+        with:
+          path: .buildxcache/
+          key: ${{ runner.os }}-buildx-${{ hashFiles('**/*.go', 'Dockerfile', 'go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build multi-platform image
+        run: make docker-buildx
+
+      - name: Push multi-platform image
+        run: make docker-push

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 include .bingo/Variables.mk
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+DOCKER_IMAGE_REPO ?= quay.io/thanos/thanos-operator
+DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))-$(shell date +%Y-%m-%d)-$(shell git rev-parse --short HEAD)
+IMG ?= ${DOCKER_IMAGE_REPO}:${DOCKER_IMAGE_TAG}
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.29.0
 


### PR DESCRIPTION
Add CI to run on push to main, and push multi-platform docker images to quay.io/thanos/thanosoperator

Repo secrets have been added.