### PR TITLE
Add util func to wrangle optional types to string

### DIFF
--- a/internal/pkg/manifests/util.go
+++ b/internal/pkg/manifests/util.go
@@ -1,6 +1,8 @@
 package manifests
 
 import (
+	"fmt"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -13,4 +15,14 @@ func IsNamespacedResource(obj client.Object) bool {
 	default:
 		return true
 	}
+}
+
+// OptionalToString returns the string representation of the given pointer
+// or an empty string if the pointer is nil. Helps avoid bunch of typecasts and nil-checks throughout.
+// Works only for basic types and not complex ones like slices, structs and maps.
+func OptionalToString[T any](ptr *T) string {
+	if ptr == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", *ptr)
 }

--- a/internal/pkg/manifests/util_test.go
+++ b/internal/pkg/manifests/util_test.go
@@ -27,3 +27,65 @@ func TestIsNamespacedResource(t *testing.T) {
 		t.Errorf("RoleBinding should be namespaced")
 	}
 }
+
+func TestOptionalToString(t *testing.T) {
+	type Custom string
+
+	var intPointer *int
+	var strPointer *string
+	var boolPointer *bool
+	var floatPointer *float64
+	var customPointer *Custom
+	var unsetNilPointer *int
+
+	c := Custom("custom")
+	i := 42
+	s := "hello"
+	b := true
+	f := 3.14
+
+	intPointer = &i
+	strPointer = &s
+	boolPointer = &b
+	floatPointer = &f
+	customPointer = &c
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{"int pointer", intPointer, "42"},
+		{"string pointer", strPointer, "hello"},
+		{"bool pointer", boolPointer, "true"},
+		{"float pointer", floatPointer, "3.14"},
+		{"custom pointer", customPointer, "custom"},
+		{"unset nil pointer", unsetNilPointer, ""},
+		{"nil int pointer", (*int)(nil), ""},
+		{"nil string pointer", (*string)(nil), ""},
+		{"nil bool pointer", (*bool)(nil), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result string
+			switch v := tt.input.(type) {
+			case *int:
+				result = OptionalToString(v)
+			case *string:
+				result = OptionalToString(v)
+			case *bool:
+				result = OptionalToString(v)
+			case *float64:
+				result = OptionalToString(v)
+			case *Custom:
+				result = OptionalToString(v)
+			default:
+				t.Fatalf("unsupported type: %T", v)
+			}
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Working on store/ruler which have a lot of basic type optionals, I think having something like this would really help avoid bunch of typecasts and nil-checks in builder logic
 
I kind of user generic as something like this feels ideal for that. But can do same with interface{} as well, just need to jump through some reflect pkg hoops