### PR TITLE
Don't import API types in builder

### DIFF
--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -195,6 +195,17 @@ func (r *ThanosQueryReconciler) buildQuerier(ctx context.Context, query monitori
 	}.ApplyDefaults()
 
 	endpoints := r.getStoreAPIServiceEndpoints(ctx, query)
+
+	additional := manifests.Additional{
+		Args:         query.Spec.Additional.Args,
+		Containers:   query.Spec.Additional.Containers,
+		Volumes:      query.Spec.Additional.Volumes,
+		VolumeMounts: query.Spec.Additional.VolumeMounts,
+		Ports:        query.Spec.Additional.Ports,
+		Env:          query.Spec.Additional.Env,
+		ServicePorts: query.Spec.Additional.ServicePorts,
+	}
+
 	return manifestquery.BuildQuerier(manifestquery.QuerierOptions{
 		Options:       metaOpts,
 		ReplicaLabels: query.Spec.QuerierReplicaLabels,
@@ -202,7 +213,7 @@ func (r *ThanosQueryReconciler) buildQuerier(ctx context.Context, query monitori
 		LookbackDelta: "5m",
 		MaxConcurrent: 20,
 		Endpoints:     endpoints,
-		Additional:    query.Spec.Additional,
+		Additional:    additional,
 	})
 }
 

--- a/internal/controller/thanosreceive_controller.go
+++ b/internal/controller/thanosreceive_controller.go
@@ -274,8 +274,18 @@ func (r *ThanosReceiveReconciler) buildHashrings(receiver monitoringthanosiov1al
 			StorageSize:    resource.MustParse(string(hashring.StorageSize)),
 			ObjStoreSecret: objStoreSecret,
 			ExternalLabels: hashring.ExternalLabels,
-			Additional:     receiver.Spec.Ingester.Additional,
 		}
+
+		opt.Additional = manifests.Additional{
+			Args:         receiver.Spec.Ingester.Additional.Args,
+			Containers:   receiver.Spec.Ingester.Additional.Containers,
+			Volumes:      receiver.Spec.Ingester.Additional.Volumes,
+			VolumeMounts: receiver.Spec.Ingester.Additional.VolumeMounts,
+			Ports:        receiver.Spec.Ingester.Additional.Ports,
+			Env:          receiver.Spec.Ingester.Additional.Env,
+			ServicePorts: receiver.Spec.Ingester.Additional.ServicePorts,
+		}
+
 		opts = append(opts, opt)
 	}
 
@@ -346,7 +356,16 @@ func (r *ThanosReceiveReconciler) buildRouter(receiver monitoringthanosiov1alpha
 		Options:           metaOpts,
 		ReplicationFactor: receiver.Spec.Router.ReplicationFactor,
 		ExternalLabels:    receiver.Spec.Router.ExternalLabels,
-		Additional:        receiver.Spec.Router.Additional,
+	}
+
+	opts.Additional = manifests.Additional{
+		Args:         receiver.Spec.Router.Additional.Args,
+		Containers:   receiver.Spec.Router.Additional.Containers,
+		Volumes:      receiver.Spec.Router.Additional.Volumes,
+		VolumeMounts: receiver.Spec.Router.Additional.VolumeMounts,
+		Ports:        receiver.Spec.Router.Additional.Ports,
+		Env:          receiver.Spec.Router.Additional.Env,
+		ServicePorts: receiver.Spec.Router.Additional.ServicePorts,
 	}
 
 	return receive.BuildRouter(opts)

--- a/internal/pkg/manifests/additional.go
+++ b/internal/pkg/manifests/additional.go
@@ -1,0 +1,25 @@
+package manifests
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type Additional struct {
+	// Additional arguments to pass to the Thanos components.
+	Args []string `json:"additionalArgs,omitempty"`
+	// Additional containers to add to the Thanos components.
+	Containers []corev1.Container `json:"additionalContainers,omitempty"`
+	// Additional volumes to add to the Thanos components.
+	Volumes []corev1.Volume `json:"additionalVolumes,omitempty"`
+	// Additional volume mounts to add to the Thanos component container in a Deployment or StatefulSet
+	// controlled by the operator.
+	VolumeMounts []corev1.VolumeMount `json:"additionalVolumeMounts,omitempty"`
+	// Additional ports to expose on the Thanos component container in a Deployment or StatefulSet
+	// controlled by the operator.
+	Ports []corev1.ContainerPort `json:"additionalPorts,omitempty"`
+	// Additional environment variables to add to the Thanos component container in a Deployment or StatefulSet
+	// controlled by the operator.
+	Env []corev1.EnvVar `json:"additionalEnv,omitempty"`
+	// AdditionalServicePorts are additional ports to expose on the Service for the Thanos component.
+	ServicePorts []corev1.ServicePort `json:"additionalServicePorts,omitempty"`
+}

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -3,7 +3,6 @@ package query
 import (
 	"fmt"
 
-	monitoringthanosiov1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -38,7 +37,7 @@ type QuerierOptions struct {
 	MaxConcurrent int
 
 	Endpoints  []Endpoint
-	Additional monitoringthanosiov1alpha1.Additional
+	Additional manifests.Additional
 }
 
 type EndpointType string

--- a/internal/pkg/manifests/query/builder_test.go
+++ b/internal/pkg/manifests/query/builder_test.go
@@ -3,7 +3,6 @@ package query
 import (
 	"testing"
 
-	monitoringthanosiov1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 
 	corev1 "k8s.io/api/core/v1"
@@ -104,7 +103,7 @@ func TestNewQuerierDeployment(t *testing.T) {
 				Timeout:       "15m",
 				LookbackDelta: "5m",
 				MaxConcurrent: 20,
-				Additional: monitoringthanosiov1alpha1.Additional{
+				Additional: manifests.Additional{
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "test-sd",
@@ -130,7 +129,7 @@ func TestNewQuerierDeployment(t *testing.T) {
 				Timeout:       "15m",
 				LookbackDelta: "5m",
 				MaxConcurrent: 20,
-				Additional: monitoringthanosiov1alpha1.Additional{
+				Additional: manifests.Additional{
 					Containers: []corev1.Container{
 						{
 							Name:  "test-container",

--- a/internal/pkg/manifests/receive/builder.go
+++ b/internal/pkg/manifests/receive/builder.go
@@ -6,7 +6,6 @@ import (
 	"slices"
 	"sort"
 
-	monitoringthanosiov1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 
 	"github.com/go-logr/logr"
@@ -59,7 +58,7 @@ type IngesterOptions struct {
 	StorageSize    resource.Quantity
 	ObjStoreSecret corev1.SecretKeySelector
 	ExternalLabels map[string]string
-	Additional     monitoringthanosiov1alpha1.Additional
+	Additional     manifests.Additional
 }
 
 type TSDBOpts struct {
@@ -71,7 +70,7 @@ type RouterOptions struct {
 	manifests.Options
 	ReplicationFactor int32
 	ExternalLabels    map[string]string
-	Additional        monitoringthanosiov1alpha1.Additional
+	Additional        manifests.Additional
 }
 
 // HashringOptions for Thanos Receive hashring

--- a/internal/pkg/manifests/receive/builder_test.go
+++ b/internal/pkg/manifests/receive/builder_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	monitoringthanosiov1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 
 	"github.com/go-logr/logr/testr"
@@ -178,7 +177,7 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
 				}.ApplyDefaults(),
-				Additional: monitoringthanosiov1alpha1.Additional{
+				Additional: manifests.Additional{
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "http-config",
@@ -201,7 +200,7 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
 				}.ApplyDefaults(),
-				Additional: monitoringthanosiov1alpha1.Additional{
+				Additional: manifests.Additional{
 					Containers: []corev1.Container{
 						{
 							Name:  "test-container",
@@ -319,7 +318,7 @@ func TestNewRouterDeployment(t *testing.T) {
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
 				}.ApplyDefaults(),
-				Additional: monitoringthanosiov1alpha1.Additional{
+				Additional: manifests.Additional{
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "http-config",
@@ -342,7 +341,7 @@ func TestNewRouterDeployment(t *testing.T) {
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
 				}.ApplyDefaults(),
-				Additional: monitoringthanosiov1alpha1.Additional{
+				Additional: manifests.Additional{
 					Containers: []corev1.Container{
 						{
 							Name:  "test-container",


### PR DESCRIPTION
As part of https://github.com/thanos-community/thanos-operator/pull/48#discussion_r1675482024 