### PR TITLE
ctrl: Refactor options conversions for readability

### DIFF
--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -153,7 +153,7 @@ func (r *ThanosQueryReconciler) buildQuery(ctx context.Context, query monitoring
 		return []client.Object{}, err
 	}
 
-	opts := queryAlphaV1ToOptions(query)
+	opts := queryV1Alpha1ToOptions(query)
 	opts.Endpoints = endpoints
 
 	return manifestquery.BuildQuery(opts), nil
@@ -206,7 +206,7 @@ func (r *ThanosQueryReconciler) getStoreAPIServiceEndpoints(ctx context.Context,
 }
 
 func (r *ThanosQueryReconciler) buildQueryFrontend(query monitoringthanosiov1alpha1.ThanosQuery) []client.Object {
-	options := queryAlphaV1ToQueryFrontEndOptions(query)
+	options := queryV1Alpha1ToQueryFrontEndOptions(query)
 	return manifestqueryfrontend.BuildQueryFrontend(options)
 }
 

--- a/internal/controller/thanosquery_controller_test.go
+++ b/internal/controller/thanosquery_controller_test.go
@@ -104,7 +104,7 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 			By("setting up the thanos query resources", func() {
 				Expect(k8sClient.Create(context.Background(), resource)).Should(Succeed())
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.Deployment{}, queryV1Alpha1NameFromParent(resourceName), ns)
+					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.Deployment{}, QueryNameFromParent(resourceName), ns)
 				}, time.Minute*1, time.Second*10).Should(BeTrue())
 			})
 
@@ -123,7 +123,7 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 				Expect(k8sClient.Create(context.Background(), svc)).Should(Succeed())
 				expectArg := fmt.Sprintf("--endpoint=dnssrv+_%s._tcp.%s.%s.svc.cluster.local", receive.GRPCPortName, receiveSvcName, ns)
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyDeploymentArgs(k8sClient, queryV1Alpha1NameFromParent(resourceName), ns, 0, expectArg)
+					return utils.VerifyDeploymentArgs(k8sClient, QueryNameFromParent(resourceName), ns, 0, expectArg)
 				}, time.Minute*1, time.Second*10).Should(BeTrue())
 			})
 
@@ -159,7 +159,7 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 				EventuallyWithOffset(1, func() error {
 					deployment := &appsv1.Deployment{}
 					if err := k8sClient.Get(ctx, types.NamespacedName{
-						Name:      queryV1Alpha1NameFromParent(resourceName),
+						Name:      QueryNameFromParent(resourceName),
 						Namespace: ns,
 					}, deployment); err != nil {
 						return err
@@ -172,11 +172,11 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 					}
 
 					arg := fmt.Sprintf("--endpoint-strict=dnssrv+_%s._tcp.%s.%s.svc.cluster.local", receive.GRPCPortName, receiveSvcName, ns)
-					if utils.VerifyDeploymentArgs(k8sClient, queryV1Alpha1NameFromParent(resourceName), ns, 0, arg) == false {
+					if utils.VerifyDeploymentArgs(k8sClient, QueryNameFromParent(resourceName), ns, 0, arg) == false {
 						return fmt.Errorf("expected arg %q", arg)
 					}
 
-					if utils.VerifyDeploymentArgs(k8sClient, queryV1Alpha1NameFromParent(resourceName), ns, 1, "--reporter.grpc.host-port=jaeger-collector:14250") == false {
+					if utils.VerifyDeploymentArgs(k8sClient, QueryNameFromParent(resourceName), ns, 1, "--reporter.grpc.host-port=jaeger-collector:14250") == false {
 						return fmt.Errorf("expected arg for additional container --reporter.grpc.host-port=jaeger-collector:14250")
 					}
 
@@ -207,7 +207,7 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 				Expect(k8sClient.Update(context.Background(), resource)).Should(Succeed())
 
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.Deployment{}, queryFrontendV1Alpha1NameFromParent(resourceName), ns)
+					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.Deployment{}, QueryFrontendNameFromParent(resourceName), ns)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 			})
 
@@ -223,7 +223,7 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 					}
 
 					for _, expectedArg := range expectedArgs {
-						if !utils.VerifyDeploymentArgs(k8sClient, queryFrontendV1Alpha1NameFromParent(resourceName), ns, 0, expectedArg) {
+						if !utils.VerifyDeploymentArgs(k8sClient, QueryFrontendNameFromParent(resourceName), ns, 0, expectedArg) {
 							return fmt.Errorf("expected arg %q not found", expectedArg)
 						}
 					}
@@ -234,8 +234,8 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 
 			By("verifying query frontend is linked to query service", func() {
 				EventuallyWithOffset(1, func() error {
-					expectedArg := fmt.Sprintf("--query-frontend.downstream-url=http://%s.%s.svc.cluster.local:9090", queryV1Alpha1NameFromParent(resourceName), ns)
-					if !utils.VerifyDeploymentArgs(k8sClient, queryFrontendV1Alpha1NameFromParent(resourceName), ns, 0, expectedArg) {
+					expectedArg := fmt.Sprintf("--query-frontend.downstream-url=http://%s.%s.svc.cluster.local:9090", QueryNameFromParent(resourceName), ns)
+					if !utils.VerifyDeploymentArgs(k8sClient, QueryFrontendNameFromParent(resourceName), ns, 0, expectedArg) {
 						return fmt.Errorf("expected arg %q not found", expectedArg)
 					}
 					return nil
@@ -263,7 +263,7 @@ var _ = Describe("ThanosQuery Controller", Ordered, func() {
 				EventuallyWithOffset(1, func() error {
 					deployment := &appsv1.Deployment{}
 					if err := k8sClient.Get(ctx, types.NamespacedName{
-						Name:      queryV1Alpha1NameFromParent(resourceName),
+						Name:      QueryNameFromParent(resourceName),
 						Namespace: ns,
 					}, deployment); err != nil {
 						return err

--- a/internal/controller/thanosruler_controller.go
+++ b/internal/controller/thanosruler_controller.go
@@ -149,7 +149,7 @@ func (r *ThanosRulerReconciler) buildRuler(ctx context.Context, ruler monitoring
 		return []client.Object{}, err
 	}
 
-	opts := rulerAlphaV1ToOptions(ruler)
+	opts := rulerV1Alpha1ToOptions(ruler)
 	opts.Endpoints = endpoints
 	opts.RuleFiles = ruleFiles
 

--- a/internal/controller/thanosruler_controller_test.go
+++ b/internal/controller/thanosruler_controller_test.go
@@ -118,16 +118,16 @@ config:
 				Expect(k8sClient.Create(context.Background(), resource)).Should(Succeed())
 
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.StatefulSet{}, resourceName, ns)
+					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.StatefulSet{}, rulerV1Alpha1NameFromParent(resourceName), ns)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyStatefulSetArgs(k8sClient, resourceName, ns, 0, "--label=rule_replica=\"$(NAME)\"")
+					return utils.VerifyStatefulSetArgs(k8sClient, rulerV1Alpha1NameFromParent(resourceName), ns, 0, "--label=rule_replica=\"$(NAME)\"")
 				}, time.Second*30, time.Second*2).Should(BeTrue())
 
 				EventuallyWithOffset(1, func() bool {
 					return utils.VerifyStatefulSetReplicas(
-						k8sClient, 2, resourceName, ns)
+						k8sClient, 2, rulerV1Alpha1NameFromParent(resourceName), ns)
 				}, time.Second*30, time.Second*2).Should(BeTrue())
 			})
 
@@ -158,7 +158,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					arg := fmt.Sprintf("--query=dnssrv+_http._tcp.%s.%s.svc.cluster.local", "my-query", ns)
-					return utils.VerifyStatefulSetArgs(k8sClient, resourceName, ns, 0, arg)
+					return utils.VerifyStatefulSetArgs(k8sClient, rulerV1Alpha1NameFromParent(resourceName), ns, 0, arg)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 			})
 
@@ -185,7 +185,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					arg := "--rule-file=/etc/thanos/rules/my-rules.yaml"
-					return utils.VerifyStatefulSetArgs(k8sClient, resourceName, ns, 0, arg)
+					return utils.VerifyStatefulSetArgs(k8sClient, rulerV1Alpha1NameFromParent(resourceName), ns, 0, arg)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 			})
 		})

--- a/internal/controller/thanosruler_controller_test.go
+++ b/internal/controller/thanosruler_controller_test.go
@@ -118,16 +118,16 @@ config:
 				Expect(k8sClient.Create(context.Background(), resource)).Should(Succeed())
 
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.StatefulSet{}, rulerV1Alpha1NameFromParent(resourceName), ns)
+					return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.StatefulSet{}, RulerNameFromParent(resourceName), ns)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 
 				EventuallyWithOffset(1, func() bool {
-					return utils.VerifyStatefulSetArgs(k8sClient, rulerV1Alpha1NameFromParent(resourceName), ns, 0, "--label=rule_replica=\"$(NAME)\"")
+					return utils.VerifyStatefulSetArgs(k8sClient, RulerNameFromParent(resourceName), ns, 0, "--label=rule_replica=\"$(NAME)\"")
 				}, time.Second*30, time.Second*2).Should(BeTrue())
 
 				EventuallyWithOffset(1, func() bool {
 					return utils.VerifyStatefulSetReplicas(
-						k8sClient, 2, rulerV1Alpha1NameFromParent(resourceName), ns)
+						k8sClient, 2, RulerNameFromParent(resourceName), ns)
 				}, time.Second*30, time.Second*2).Should(BeTrue())
 			})
 
@@ -158,7 +158,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					arg := fmt.Sprintf("--query=dnssrv+_http._tcp.%s.%s.svc.cluster.local", "my-query", ns)
-					return utils.VerifyStatefulSetArgs(k8sClient, rulerV1Alpha1NameFromParent(resourceName), ns, 0, arg)
+					return utils.VerifyStatefulSetArgs(k8sClient, RulerNameFromParent(resourceName), ns, 0, arg)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 			})
 
@@ -185,7 +185,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					arg := "--rule-file=/etc/thanos/rules/my-rules.yaml"
-					return utils.VerifyStatefulSetArgs(k8sClient, rulerV1Alpha1NameFromParent(resourceName), ns, 0, arg)
+					return utils.VerifyStatefulSetArgs(k8sClient, RulerNameFromParent(resourceName), ns, 0, arg)
 				}, time.Minute, time.Second*2).Should(BeTrue())
 			})
 		})

--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -148,17 +148,17 @@ func (r *ThanosStoreReconciler) specToOptions(store monitoringthanosiov1alpha1.T
 	// no sharding strategy, or sharding strategy with 1 shard, return a single store
 	if store.Spec.ShardingStrategy.Shards == 0 || store.Spec.ShardingStrategy.Shards == 1 {
 		return map[string]manifestsstore.Options{
-			store.GetName(): storeAlphaV1ToOptions(store),
+			store.GetName(): storeV1Alpha1ToOptions(store),
 		}
 	}
 
 	shardCount := int(store.Spec.ShardingStrategy.Shards)
 	shardedOptions := make(map[string]manifestsstore.Options, shardCount)
-	parentName := storeV1AlphaV1NameFromSpec(store)
+	parentName := storeV1Alpha1NameFromParent(store.GetName())
 
 	for i := range store.Spec.ShardingStrategy.Shards {
 		shardName := storeShardName(parentName, i)
-		storeShardOpts := storeAlphaV1ToOptions(store)
+		storeShardOpts := storeV1Alpha1ToOptions(store)
 		storeShardOpts.ShardName = shardName
 		storeShardOpts.RelabelConfigs = manifests.RelabelConfigs{
 			{

--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -154,10 +154,9 @@ func (r *ThanosStoreReconciler) specToOptions(store monitoringthanosiov1alpha1.T
 
 	shardCount := int(store.Spec.ShardingStrategy.Shards)
 	shardedOptions := make(map[string]manifestsstore.Options, shardCount)
-	parentName := storeV1Alpha1NameFromParent(store.GetName())
 
 	for i := range store.Spec.ShardingStrategy.Shards {
-		shardName := storeShardName(parentName, i)
+		shardName := StoreShardName(store.GetName(), i)
 		storeShardOpts := storeV1Alpha1ToOptions(store)
 		storeShardOpts.ShardName = shardName
 		storeShardOpts.RelabelConfigs = manifests.RelabelConfigs{
@@ -194,10 +193,4 @@ func (r *ThanosStoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return nil
-}
-
-// storeShardName generates name for a Thanos Store shard.
-func storeShardName(parentName string, shardIndex int32) string {
-	name := fmt.Sprintf("%s-shard-%d", parentName, shardIndex)
-	return name
 }

--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -32,7 +32,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 
@@ -146,35 +145,20 @@ func (r *ThanosStoreReconciler) buildStore(store monitoringthanosiov1alpha1.Than
 }
 
 func (r *ThanosStoreReconciler) specToOptions(store monitoringthanosiov1alpha1.ThanosStore) map[string]manifestsstore.Options {
-	// build the shared options
-	opts := r.specToManifestOptions(store)
-
-	// buildOpts returns the Options for a Thanos Store.
-	buildOpts := func() manifestsstore.Options {
-		return manifestsstore.Options{
-			ObjStoreSecret:           store.Spec.ObjectStorageConfig.ToSecretKeySelector(),
-			IndexCacheConfig:         store.Spec.IndexCacheConfig,
-			CachingBucketConfig:      store.Spec.CachingBucketConfig,
-			Min:                      manifests.Duration(manifests.OptionalToString(store.Spec.MinTime)),
-			Max:                      manifests.Duration(manifests.OptionalToString(store.Spec.MaxTime)),
-			IgnoreDeletionMarksDelay: manifests.Duration(store.Spec.IgnoreDeletionMarksDelay),
-			StorageSize:              resource.MustParse(string(store.Spec.StorageSize)),
-			Options:                  opts,
-		}
-	}
 	// no sharding strategy, or sharding strategy with 1 shard, return a single store
 	if store.Spec.ShardingStrategy.Shards == 0 || store.Spec.ShardingStrategy.Shards == 1 {
 		return map[string]manifestsstore.Options{
-			store.GetName(): buildOpts(),
+			store.GetName(): storeAlphaV1ToOptions(store),
 		}
 	}
 
 	shardCount := int(store.Spec.ShardingStrategy.Shards)
 	shardedOptions := make(map[string]manifestsstore.Options, shardCount)
+	parentName := storeV1AlphaV1NameFromSpec(store)
 
 	for i := range store.Spec.ShardingStrategy.Shards {
-		shardName := storeShardName(store.GetName(), i)
-		storeShardOpts := buildOpts()
+		shardName := storeShardName(parentName, i)
+		storeShardOpts := storeAlphaV1ToOptions(store)
 		storeShardOpts.ShardName = shardName
 		storeShardOpts.RelabelConfigs = manifests.RelabelConfigs{
 			{
@@ -192,28 +176,6 @@ func (r *ThanosStoreReconciler) specToOptions(store monitoringthanosiov1alpha1.T
 		shardedOptions[shardName] = storeShardOpts
 	}
 	return shardedOptions
-}
-
-func (r *ThanosStoreReconciler) specToManifestOptions(store monitoringthanosiov1alpha1.ThanosStore) manifests.Options {
-	return manifests.Options{
-		Name:                 store.GetName(),
-		Namespace:            store.GetNamespace(),
-		Replicas:             store.Spec.ShardingStrategy.ShardReplicas,
-		Labels:               manifests.MergeLabels(store.GetLabels(), store.Spec.Labels),
-		Image:                store.Spec.Image,
-		LogLevel:             store.Spec.LogLevel,
-		LogFormat:            store.Spec.LogFormat,
-		ResourceRequirements: store.Spec.ResourceRequirements,
-		Additional: manifests.Additional{
-			Args:         store.Spec.Args,
-			Containers:   store.Spec.Containers,
-			Env:          store.Spec.Env,
-			Volumes:      store.Spec.Volumes,
-			VolumeMounts: store.Spec.VolumeMounts,
-			Ports:        store.Spec.Ports,
-			ServicePorts: store.Spec.ServicePorts,
-		},
-	}
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -237,6 +199,5 @@ func (r *ThanosStoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // storeShardName generates name for a Thanos Store shard.
 func storeShardName(parentName string, shardIndex int32) string {
 	name := fmt.Sprintf("%s-shard-%d", parentName, shardIndex)
-	// todo - figure out a strategy for global naming for all resources
 	return name
 }

--- a/internal/controller/thanosstore_controller_test.go
+++ b/internal/controller/thanosstore_controller_test.go
@@ -119,8 +119,7 @@ config:
 
 			By("setting up the thanos store resources", func() {
 				Expect(k8sClient.Create(context.Background(), resource)).Should(Succeed())
-				name := storeV1Alpha1NameFromParent(resourceName)
-				expect := []string{storeShardName(name, 0), storeShardName(name, 1), storeShardName(name, 2)}
+				expect := []string{StoreShardName(resourceName, 0), StoreShardName(resourceName, 1), StoreShardName(resourceName, 2)}
 				for _, shard := range expect {
 					EventuallyWithOffset(1, func() bool {
 						return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.StatefulSet{}, shard, ns)
@@ -133,7 +132,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					return utils.VerifyStatefulSetReplicas(
-						k8sClient, 2, storeShardName(name, 2), ns)
+						k8sClient, 2, StoreShardName(resourceName, 2), ns)
 				}, time.Second*10, time.Second*2).Should(BeTrue())
 			})
 
@@ -147,7 +146,7 @@ config:
 - action: keep
   source_labels: ["shard"]
   regex: 0`
-					return utils.VerifyStatefulSetArgs(k8sClient, storeShardName(storeV1Alpha1NameFromParent(resourceName), 0), ns, 0, args)
+					return utils.VerifyStatefulSetArgs(k8sClient, StoreShardName(resourceName, 0), ns, 0, args)
 				}, time.Second*10, time.Second*2).Should(BeTrue())
 			})
 
@@ -155,7 +154,7 @@ config:
 				EventuallyWithOffset(1, func() bool {
 					statefulSet := &appsv1.StatefulSet{}
 					if err := k8sClient.Get(ctx, types.NamespacedName{
-						Name:      storeShardName(storeV1Alpha1NameFromParent(resourceName), 0),
+						Name:      StoreShardName(resourceName, 0),
 						Namespace: ns,
 					}, statefulSet); err != nil {
 						return false
@@ -185,7 +184,7 @@ config:
 					if !utils.VerifyCfgMapOrSecretEnvVarExists(
 						k8sClient,
 						&appsv1.StatefulSet{},
-						storeShardName(storeV1Alpha1NameFromParent(resourceName), 0),
+						StoreShardName(resourceName, 0),
 						ns,
 						0,
 						"INDEX_CACHE_CONFIG",
@@ -197,7 +196,7 @@ config:
 					if !utils.VerifyCfgMapOrSecretEnvVarExists(
 						k8sClient,
 						&appsv1.StatefulSet{},
-						storeShardName(storeV1Alpha1NameFromParent(resourceName), 0),
+						StoreShardName(resourceName, 0),
 						ns,
 						0,
 						"CACHING_BUCKET_CONFIG",
@@ -218,7 +217,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					return utils.VerifyStatefulSetReplicas(
-						k8sClient, 2, storeShardName(storeV1Alpha1NameFromParent(resourceName), 0), ns)
+						k8sClient, 2, StoreShardName(resourceName, 0), ns)
 				}, time.Second*10, time.Second*2).Should(BeTrue())
 			})
 		})

--- a/internal/controller/thanosstore_controller_test.go
+++ b/internal/controller/thanosstore_controller_test.go
@@ -119,8 +119,8 @@ config:
 
 			By("setting up the thanos store resources", func() {
 				Expect(k8sClient.Create(context.Background(), resource)).Should(Succeed())
-
-				expect := []string{resourceName + "-shard-0", resourceName + "-shard-1", resourceName + "-shard-2"}
+				name := storeV1Alpha1NameFromParent(resourceName)
+				expect := []string{storeShardName(name, 0), storeShardName(name, 1), storeShardName(name, 2)}
 				for _, shard := range expect {
 					EventuallyWithOffset(1, func() bool {
 						return utils.VerifyNamedServiceAndWorkloadExists(k8sClient, &appsv1.StatefulSet{}, shard, ns)
@@ -133,7 +133,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					return utils.VerifyStatefulSetReplicas(
-						k8sClient, 2, resourceName+"-shard-2", ns)
+						k8sClient, 2, storeShardName(name, 2), ns)
 				}, time.Second*10, time.Second*2).Should(BeTrue())
 			})
 
@@ -147,7 +147,7 @@ config:
 - action: keep
   source_labels: ["shard"]
   regex: 0`
-					return utils.VerifyStatefulSetArgs(k8sClient, resourceName+"-shard-0", ns, 0, args)
+					return utils.VerifyStatefulSetArgs(k8sClient, storeShardName(storeV1Alpha1NameFromParent(resourceName), 0), ns, 0, args)
 				}, time.Second*10, time.Second*2).Should(BeTrue())
 			})
 
@@ -155,7 +155,7 @@ config:
 				EventuallyWithOffset(1, func() bool {
 					statefulSet := &appsv1.StatefulSet{}
 					if err := k8sClient.Get(ctx, types.NamespacedName{
-						Name:      resourceName + "-shard-0",
+						Name:      storeShardName(storeV1Alpha1NameFromParent(resourceName), 0),
 						Namespace: ns,
 					}, statefulSet); err != nil {
 						return false
@@ -185,7 +185,7 @@ config:
 					if !utils.VerifyCfgMapOrSecretEnvVarExists(
 						k8sClient,
 						&appsv1.StatefulSet{},
-						resourceName+"-shard-0",
+						storeShardName(storeV1Alpha1NameFromParent(resourceName), 0),
 						ns,
 						0,
 						"INDEX_CACHE_CONFIG",
@@ -197,7 +197,7 @@ config:
 					if !utils.VerifyCfgMapOrSecretEnvVarExists(
 						k8sClient,
 						&appsv1.StatefulSet{},
-						resourceName+"-shard-0",
+						storeShardName(storeV1Alpha1NameFromParent(resourceName), 0),
 						ns,
 						0,
 						"CACHING_BUCKET_CONFIG",
@@ -218,7 +218,7 @@ config:
 
 				EventuallyWithOffset(1, func() bool {
 					return utils.VerifyStatefulSetReplicas(
-						k8sClient, 2, resourceName+"-shard-0", ns)
+						k8sClient, 2, storeShardName(storeV1Alpha1NameFromParent(resourceName), 0), ns)
 				}, time.Second*10, time.Second*2).Should(BeTrue())
 			})
 		})

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -1,0 +1,124 @@
+package controller
+
+import (
+	"fmt"
+	"github.com/thanos-community/thanos-operator/api/v1alpha1"
+	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+	manifestquery "github.com/thanos-community/thanos-operator/internal/pkg/manifests/query"
+	manifestqueryfrontend "github.com/thanos-community/thanos-operator/internal/pkg/manifests/queryfrontend"
+	manifestruler "github.com/thanos-community/thanos-operator/internal/pkg/manifests/ruler"
+	manifestsstore "github.com/thanos-community/thanos-operator/internal/pkg/manifests/store"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func queryAlphaV1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
+	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
+	opts := commonToOpts(queryV1AlphaV1NameFromSpec(in), in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
+	return manifestquery.Options{
+		Options:       opts,
+		ReplicaLabels: in.Spec.QuerierReplicaLabels,
+		Timeout:       "15m",
+		LookbackDelta: "5m",
+		MaxConcurrent: 20,
+	}
+}
+
+func queryV1AlphaV1NameFromSpec(in v1alpha1.ThanosQuery) string {
+	return fmt.Sprintf("thanos-query-%s", in.GetName())
+}
+
+// queryAlphaV1ToQueryFrontEndOptions transforms a v1alpha1.ThanosQuery to a build Options
+func queryAlphaV1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryfrontend.Options {
+	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
+	name := queryFrontendV1AlphaV1NameFromSpec(in)
+	frontend := in.Spec.QueryFrontend
+	opts := commonToOpts(name, in.GetNamespace(), frontend.Replicas, labels, frontend.CommonThanosFields, frontend.Additional)
+
+	return manifestqueryfrontend.Options{
+		Options:                opts,
+		QueryService:           name,
+		QueryPort:              manifestquery.HTTPPort,
+		LogQueriesLongerThan:   manifests.Duration(manifests.OptionalToString(frontend.LogQueriesLongerThan)),
+		CompressResponses:      frontend.CompressResponses,
+		ResponseCacheConfig:    frontend.QueryRangeResponseCacheConfig,
+		RangeSplitInterval:     manifests.Duration(manifests.OptionalToString(frontend.QueryRangeSplitInterval)),
+		LabelsSplitInterval:    manifests.Duration(manifests.OptionalToString(frontend.LabelsSplitInterval)),
+		RangeMaxRetries:        frontend.QueryRangeMaxRetries,
+		LabelsMaxRetries:       frontend.LabelsMaxRetries,
+		LabelsDefaultTimeRange: manifests.Duration(manifests.OptionalToString(frontend.LabelsDefaultTimeRange)),
+	}
+}
+
+func queryFrontendV1AlphaV1NameFromSpec(in v1alpha1.ThanosQuery) string {
+	return fmt.Sprintf("thanos-query-frontend-%s", in.GetName())
+}
+
+func rulerAlphaV1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
+	labels := manifests.MergeLabels(in.GetLabels(), nil)
+	opts := commonToOpts(rulerV1AlphaV1NameFromSpec(in), in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
+	return manifestruler.Options{
+		Options:            opts,
+		ObjStoreSecret:     in.Spec.ObjectStorageConfig.ToSecretKeySelector(),
+		Retention:          manifests.Duration(in.Spec.Retention),
+		AlertmanagerURL:    in.Spec.AlertmanagerURL,
+		ExternalLabels:     in.Spec.ExternalLabels,
+		AlertLabelDrop:     in.Spec.AlertLabelDrop,
+		StorageSize:        resource.MustParse(in.Spec.StorageSize),
+		EvaluationInterval: manifests.Duration(in.Spec.EvaluationInterval),
+	}
+}
+
+func rulerV1AlphaV1NameFromSpec(in v1alpha1.ThanosRuler) string {
+	return fmt.Sprintf("thanos-ruler-%s", in.GetName())
+}
+
+func storeAlphaV1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
+	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
+	opts := commonToOpts(storeV1AlphaV1NameFromSpec(in), in.GetNamespace(), in.Spec.ShardingStrategy.ShardReplicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
+	return manifestsstore.Options{
+		ObjStoreSecret:           in.Spec.ObjectStorageConfig.ToSecretKeySelector(),
+		IndexCacheConfig:         in.Spec.IndexCacheConfig,
+		CachingBucketConfig:      in.Spec.CachingBucketConfig,
+		Min:                      manifests.Duration(manifests.OptionalToString(in.Spec.MinTime)),
+		Max:                      manifests.Duration(manifests.OptionalToString(in.Spec.MaxTime)),
+		IgnoreDeletionMarksDelay: manifests.Duration(in.Spec.IgnoreDeletionMarksDelay),
+		StorageSize:              resource.MustParse(string(in.Spec.StorageSize)),
+		Options:                  opts,
+	}
+}
+
+func storeV1AlphaV1NameFromSpec(in v1alpha1.ThanosStore) string {
+	return fmt.Sprintf("thanos-store-%s", in.GetName())
+}
+
+func commonToOpts(
+	name,
+	namespace string,
+	replicas int32,
+	labels map[string]string,
+	common v1alpha1.CommonThanosFields,
+	additional v1alpha1.Additional) manifests.Options {
+	return manifests.Options{
+		Name:                 name,
+		Namespace:            namespace,
+		Replicas:             replicas,
+		Labels:               labels,
+		Image:                common.Image,
+		ResourceRequirements: common.ResourceRequirements,
+		LogLevel:             common.LogLevel,
+		LogFormat:            common.LogFormat,
+		Additional:           additionalToOpts(additional),
+	}
+}
+
+func additionalToOpts(in v1alpha1.Additional) manifests.Additional {
+	return manifests.Additional{
+		Args:         in.Args,
+		Containers:   in.Containers,
+		Volumes:      in.Volumes,
+		VolumeMounts: in.VolumeMounts,
+		Ports:        in.Ports,
+		Env:          in.Env,
+		ServicePorts: in.ServicePorts,
+	}
+}

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+
 	"github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	manifestquery "github.com/thanos-community/thanos-operator/internal/pkg/manifests/query"
@@ -11,9 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func queryAlphaV1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
+func queryV1Alpha1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
-	opts := commonToOpts(queryV1AlphaV1NameFromSpec(in), in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
+	name := queryV1Alpha1NameFromParent(in.GetName())
+	opts := commonToOpts(name, in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
 	return manifestquery.Options{
 		Options:       opts,
 		ReplicaLabels: in.Spec.QuerierReplicaLabels,
@@ -23,20 +25,20 @@ func queryAlphaV1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
 	}
 }
 
-func queryV1AlphaV1NameFromSpec(in v1alpha1.ThanosQuery) string {
-	return fmt.Sprintf("thanos-query-%s", in.GetName())
+func queryV1Alpha1NameFromParent(resourceName string) string {
+	return fmt.Sprintf("thanos-query-%s", resourceName)
 }
 
-// queryAlphaV1ToQueryFrontEndOptions transforms a v1alpha1.ThanosQuery to a build Options
-func queryAlphaV1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryfrontend.Options {
+// queryV1Alpha1ToQueryFrontEndOptions transforms a v1alpha1.ThanosQuery to a build Options
+func queryV1Alpha1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryfrontend.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
-	name := queryFrontendV1AlphaV1NameFromSpec(in)
+	name := queryFrontendV1Alpha1NameFromParent(in.GetName())
 	frontend := in.Spec.QueryFrontend
 	opts := commonToOpts(name, in.GetNamespace(), frontend.Replicas, labels, frontend.CommonThanosFields, frontend.Additional)
 
 	return manifestqueryfrontend.Options{
 		Options:                opts,
-		QueryService:           name,
+		QueryService:           queryV1Alpha1NameFromParent(in.GetName()),
 		QueryPort:              manifestquery.HTTPPort,
 		LogQueriesLongerThan:   manifests.Duration(manifests.OptionalToString(frontend.LogQueriesLongerThan)),
 		CompressResponses:      frontend.CompressResponses,
@@ -49,13 +51,14 @@ func queryAlphaV1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryfr
 	}
 }
 
-func queryFrontendV1AlphaV1NameFromSpec(in v1alpha1.ThanosQuery) string {
-	return fmt.Sprintf("thanos-query-frontend-%s", in.GetName())
+func queryFrontendV1Alpha1NameFromParent(resourceName string) string {
+	return fmt.Sprintf("thanos-query-frontend-%s", resourceName)
 }
 
-func rulerAlphaV1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
+func rulerV1Alpha1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), nil)
-	opts := commonToOpts(rulerV1AlphaV1NameFromSpec(in), in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
+	name := rulerV1Alpha1NameFromParent(in.GetName())
+	opts := commonToOpts(name, in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
 	return manifestruler.Options{
 		Options:            opts,
 		ObjStoreSecret:     in.Spec.ObjectStorageConfig.ToSecretKeySelector(),
@@ -68,13 +71,14 @@ func rulerAlphaV1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
 	}
 }
 
-func rulerV1AlphaV1NameFromSpec(in v1alpha1.ThanosRuler) string {
-	return fmt.Sprintf("thanos-ruler-%s", in.GetName())
+func rulerV1Alpha1NameFromParent(resourceName string) string {
+	return fmt.Sprintf("thanos-ruler-%s", resourceName)
 }
 
-func storeAlphaV1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
+func storeV1Alpha1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
-	opts := commonToOpts(storeV1AlphaV1NameFromSpec(in), in.GetNamespace(), in.Spec.ShardingStrategy.ShardReplicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
+	name := storeV1Alpha1NameFromParent(in.GetName())
+	opts := commonToOpts(name, in.GetNamespace(), in.Spec.ShardingStrategy.ShardReplicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
 	return manifestsstore.Options{
 		ObjStoreSecret:           in.Spec.ObjectStorageConfig.ToSecretKeySelector(),
 		IndexCacheConfig:         in.Spec.IndexCacheConfig,
@@ -87,8 +91,8 @@ func storeAlphaV1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
 	}
 }
 
-func storeV1AlphaV1NameFromSpec(in v1alpha1.ThanosStore) string {
-	return fmt.Sprintf("thanos-store-%s", in.GetName())
+func storeV1Alpha1NameFromParent(resourceName string) string {
+	return fmt.Sprintf("thanos-store-%s", resourceName)
 }
 
 func commonToOpts(

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -14,7 +14,7 @@ import (
 
 func queryV1Alpha1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
-	name := queryV1Alpha1NameFromParent(in.GetName())
+	name := QueryNameFromParent(in.GetName())
 	opts := commonToOpts(name, in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
 	return manifestquery.Options{
 		Options:       opts,
@@ -25,20 +25,21 @@ func queryV1Alpha1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
 	}
 }
 
-func queryV1Alpha1NameFromParent(resourceName string) string {
+// QueryNameFromParent returns the name of the Thanos Query component.
+func QueryNameFromParent(resourceName string) string {
 	return fmt.Sprintf("thanos-query-%s", resourceName)
 }
 
 // queryV1Alpha1ToQueryFrontEndOptions transforms a v1alpha1.ThanosQuery to a build Options
 func queryV1Alpha1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryfrontend.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
-	name := queryFrontendV1Alpha1NameFromParent(in.GetName())
+	name := QueryFrontendNameFromParent(in.GetName())
 	frontend := in.Spec.QueryFrontend
 	opts := commonToOpts(name, in.GetNamespace(), frontend.Replicas, labels, frontend.CommonThanosFields, frontend.Additional)
 
 	return manifestqueryfrontend.Options{
 		Options:                opts,
-		QueryService:           queryV1Alpha1NameFromParent(in.GetName()),
+		QueryService:           QueryNameFromParent(in.GetName()),
 		QueryPort:              manifestquery.HTTPPort,
 		LogQueriesLongerThan:   manifests.Duration(manifests.OptionalToString(frontend.LogQueriesLongerThan)),
 		CompressResponses:      frontend.CompressResponses,
@@ -51,13 +52,14 @@ func queryV1Alpha1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryf
 	}
 }
 
-func queryFrontendV1Alpha1NameFromParent(resourceName string) string {
+// QueryFrontendNameFromParent returns the name of the Thanos Query Frontend component.
+func QueryFrontendNameFromParent(resourceName string) string {
 	return fmt.Sprintf("thanos-query-frontend-%s", resourceName)
 }
 
 func rulerV1Alpha1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), nil)
-	name := rulerV1Alpha1NameFromParent(in.GetName())
+	name := RulerNameFromParent(in.GetName())
 	opts := commonToOpts(name, in.GetNamespace(), in.Spec.Replicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
 	return manifestruler.Options{
 		Options:            opts,
@@ -71,13 +73,14 @@ func rulerV1Alpha1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
 	}
 }
 
-func rulerV1Alpha1NameFromParent(resourceName string) string {
+// RulerNameFromParent returns the name of the Thanos Ruler component.
+func RulerNameFromParent(resourceName string) string {
 	return fmt.Sprintf("thanos-ruler-%s", resourceName)
 }
 
 func storeV1Alpha1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
 	labels := manifests.MergeLabels(in.GetLabels(), in.Spec.Labels)
-	name := storeV1Alpha1NameFromParent(in.GetName())
+	name := StoreNameFromParent(in.GetName())
 	opts := commonToOpts(name, in.GetNamespace(), in.Spec.ShardingStrategy.ShardReplicas, labels, in.Spec.CommonThanosFields, in.Spec.Additional)
 	return manifestsstore.Options{
 		ObjStoreSecret:           in.Spec.ObjectStorageConfig.ToSecretKeySelector(),
@@ -91,8 +94,14 @@ func storeV1Alpha1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
 	}
 }
 
-func storeV1Alpha1NameFromParent(resourceName string) string {
+// StoreNameFromParent returns the name of the Thanos Store component.
+func StoreNameFromParent(resourceName string) string {
 	return fmt.Sprintf("thanos-store-%s", resourceName)
+}
+
+// StoreShardName returns the name of the Thanos Store shard.
+func StoreShardName(resourceName string, shard int32) string {
+	return fmt.Sprintf("%s-shard-%d", StoreNameFromParent(resourceName), shard)
 }
 
 func commonToOpts(


### PR DESCRIPTION
Prior to this change, there was a likely possibility that if you created two separate CRs for controllers, there would be issues with the naming

Say ThanosReceive: xyz and ThanosStore: xyz would both try to create statefulsets of the same name. This change takes care of that by adding a prefix for the names and making them discoverable from other packages (ie tests). 

We will likely still want to add validation to the names but at least it is clear where and what is happening now.

Receive isnt included here because it needs its own refactor.

