### PR TITLE
Fix spamming reconciliations for store due to label churn on ConfigMap 

### DIFF
--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -153,7 +153,8 @@ func (r *ThanosStoreReconciler) specToOptions(store monitoringthanosiov1alpha1.T
 	for i := range store.Spec.ShardingStrategy.Shards {
 		shardName := StoreShardName(store.GetName(), i)
 		storeShardOpts := storeV1Alpha1ToOptions(store)
-		storeShardOpts.ShardName = shardName
+		storeShardOpts.Instance = store.GetName()
+		storeShardOpts.Name = shardName
 		storeShardOpts.RelabelConfigs = manifests.RelabelConfigs{
 			{
 				Action:      "hashmod",

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -45,7 +45,7 @@ type Options struct {
 	IgnoreDeletionMarksDelay manifests.Duration
 	Min, Max                 manifests.Duration
 	RelabelConfigs           manifests.RelabelConfigs
-	// Instance is the owner of the ingester and if not set, defaults to the name of the object.
+	// Instance is the owner of the Store and if not set, defaults to the name of the object.
 	Instance string
 }
 


### PR DESCRIPTION
This took me awhile to track down. Essentially we want the in-memory cache config ConfigMap to be a singleton so this avoids having an endless reconciliation loop by setting strict static labels on that resource.