### PR TITLE
feature: Adds PodDisruptionBudgets for remaining components

### DIFF
--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -203,6 +203,10 @@ func commonToOpts(
 	labels map[string]string,
 	common v1alpha1.CommonThanosFields,
 	additional v1alpha1.Additional) manifests.Options {
+	var pdbConfig *manifests.PodDisruptionBudgetOptions
+	if replicas > 1 {
+		pdbConfig = &manifests.PodDisruptionBudgetOptions{}
+	}
 	return manifests.Options{
 		Owner:                owner.GetName(),
 		Namespace:            owner.GetNamespace(),
@@ -214,6 +218,7 @@ func commonToOpts(
 		LogFormat:            common.LogFormat,
 		Additional:           additionalToOpts(additional),
 		ServiceMonitorConfig: serviceMonitorConfigToOpts(common.ServiceMonitorConfig, owner.GetNamespace(), labels),
+		PodDisruptionConfig:  pdbConfig,
 	}
 }
 

--- a/internal/pkg/manifests/compact/builder.go
+++ b/internal/pkg/manifests/compact/builder.go
@@ -52,6 +52,10 @@ type Options struct {
 	ShardIndex *int
 }
 
+// Build compiles all the Kubernetes objects for the Thanos Compact shard.
+// This includes the ServiceAccount, StatefulSet, and Service.
+// Build ignores any manifests.PodDisruptionBudgetOptions as well as replicas set in the Options since
+// enforce running compactor as a single replica.
 func (opts Options) Build() []client.Object {
 	var objs []client.Object
 	selectorLabels := opts.GetSelectorLabels()

--- a/internal/pkg/manifests/compact/builder_test.go
+++ b/internal/pkg/manifests/compact/builder_test.go
@@ -156,6 +156,8 @@ func TestBuild(t *testing.T) {
 				"some-other-label":       someOtherLabelValue,
 				"app.kubernetes.io/name": "expect-to-be-discarded",
 			},
+			// should ignore this setting
+			PodDisruptionConfig: &manifests.PodDisruptionBudgetOptions{},
 		},
 	}
 

--- a/internal/pkg/manifests/options.go
+++ b/internal/pkg/manifests/options.go
@@ -90,6 +90,9 @@ type Options struct {
 	LogFormat *string
 	//ServiceMonitorConfig is the configuration for the ServiceMonitor
 	ServiceMonitorConfig ServiceMonitorConfig
+	// PodDisruptionConfig is the configuration for the PodDisruptionBudget
+	// If not set, the PodDisruptionBudget will not be created.
+	PodDisruptionConfig *PodDisruptionBudgetOptions
 }
 
 // ValidateAndSanitizeResourceName sanitizes the provided name to a valid DNS-1123 subdomain.

--- a/internal/pkg/manifests/pdb.go
+++ b/internal/pkg/manifests/pdb.go
@@ -4,18 +4,25 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
+
+// PodDisruptionBudgetOptions defines the available options for creating a PodDisruptionBudget object.
+type PodDisruptionBudgetOptions struct {
+	// MaxUnavailable is the maximum number of pods that can be unavailable during the disruption.
+	// Defaults to 1 if not specified.
+	MaxUnavailable *int32
+	// MinAvailable is the minimum number of pods that must still be available during the disruption.
+	// Defaults to nil if not specified.
+	MinAvailable *int32
+}
 
 // NewPodDisruptionBudget creates a new PodDisruptionBudget object.
 // It sets the object name, namespace, selector labels, object meta labels, and maxUnavailable.
 // The maxUnavailable is a pointer to an int32 value.
 // If the maxUnavailable is nil, it defaults to 1.
-func NewPodDisruptionBudget(name, namespace string, selectorLabels, objectMetaLabels map[string]string, maxUnavailable *int) *policyv1.PodDisruptionBudget {
-	value := 1
-	if maxUnavailable != nil {
-		value = *maxUnavailable
-	}
-	mu := intstr.FromInt32(int32(value))
+func NewPodDisruptionBudget(name, namespace string, selectorLabels, objectMetaLabels map[string]string, opts PodDisruptionBudgetOptions) *policyv1.PodDisruptionBudget {
+	minValue, maxValue := opts.getMinAndMax()
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PodDisruptionBudget",
@@ -30,7 +37,23 @@ func NewPodDisruptionBudget(name, namespace string, selectorLabels, objectMetaLa
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
-			MaxUnavailable: &mu,
+			MinAvailable:   minValue,
+			MaxUnavailable: maxValue,
 		},
 	}
+}
+
+func (opts PodDisruptionBudgetOptions) getMinAndMax() (min *intstr.IntOrString, max *intstr.IntOrString) {
+	if opts.MinAvailable != nil {
+		minValue := intstr.FromInt32(*opts.MinAvailable)
+		min = &minValue
+	}
+
+	if opts.MaxUnavailable == nil {
+		opts.MaxUnavailable = ptr.To(int32(1))
+	}
+
+	maxValue := intstr.FromInt32(*opts.MaxUnavailable)
+	max = &maxValue
+	return min, max
 }

--- a/internal/pkg/manifests/pdb_test.go
+++ b/internal/pkg/manifests/pdb_test.go
@@ -2,8 +2,6 @@ package manifests
 
 import (
 	"testing"
-
-	"k8s.io/utils/ptr"
 )
 
 func TestNewPodDisruptionBudget(t *testing.T) {
@@ -12,7 +10,7 @@ func TestNewPodDisruptionBudget(t *testing.T) {
 		namespace        string
 		selectorLabels   map[string]string
 		objectMetaLabels map[string]string
-		maxUnavailable   int
+		conf             PodDisruptionBudgetOptions
 	}
 	tests := []struct {
 		name string
@@ -25,22 +23,21 @@ func TestNewPodDisruptionBudget(t *testing.T) {
 				namespace:        "test-namespace",
 				selectorLabels:   map[string]string{"test": "label"},
 				objectMetaLabels: map[string]string{"test": "label"},
-				maxUnavailable:   1,
+				conf:             PodDisruptionBudgetOptions{},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mu := ptr.To(tt.args.maxUnavailable)
-			pdb := NewPodDisruptionBudget(tt.args.name, tt.args.namespace, tt.args.selectorLabels, tt.args.objectMetaLabels, mu)
+			pdb := NewPodDisruptionBudget(tt.args.name, tt.args.namespace, tt.args.selectorLabels, tt.args.objectMetaLabels, tt.args.conf)
 			if pdb.Name != tt.args.name {
 				t.Errorf("pdb.Name = %v, want %v", pdb.Name, tt.args.name)
 			}
 			if pdb.Namespace != tt.args.namespace {
 				t.Errorf("pdb.Namespace = %v, want %v", pdb.Namespace, tt.args.namespace)
 			}
-			if pdb.Spec.MaxUnavailable.IntVal != int32(tt.args.maxUnavailable) {
-				t.Errorf("pdb.Spec.MinAvailable.IntVal = %v, want %v", pdb.Spec.MaxUnavailable.IntVal, tt.args.maxUnavailable)
+			if pdb.Spec.MaxUnavailable.IntVal != int32(1) {
+				t.Errorf("pdb.Spec.MinAvailable.IntVal = %v, want %v", pdb.Spec.MaxUnavailable.IntVal, 1)
 			}
 		})
 	}

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -66,7 +66,11 @@ func (opts Options) Build() []client.Object {
 	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
 	objs = append(objs, newQueryDeployment(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newQueryService(opts, selectorLabels, objectMetaLabels))
-	objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, ptr.To(1)))
+
+	if opts.PodDisruptionConfig != nil {
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+	}
+
 	if opts.ServiceMonitorConfig.Enabled {
 		objs = append(objs, manifests.BuildServiceMonitor(name, opts.Namespace, objectMetaLabels, selectorLabels, serviceMonitorOpts(opts.ServiceMonitorConfig)))
 	}

--- a/internal/pkg/manifests/query/builder_test.go
+++ b/internal/pkg/manifests/query/builder_test.go
@@ -28,6 +28,7 @@ func TestBuildQuery(t *testing.T) {
 				"some-other-label":       someOtherLabelValue,
 				"app.kubernetes.io/name": "expect-to-be-discarded",
 			},
+			PodDisruptionConfig: &manifests.PodDisruptionBudgetOptions{},
 		},
 		Timeout:       "15m",
 		LookbackDelta: "5m",
@@ -42,10 +43,7 @@ func TestBuildQuery(t *testing.T) {
 	utils.ValidateIsNamedServiceAccount(t, objs[0], opts, opts.Namespace)
 	utils.ValidateObjectsEqual(t, objs[1], NewQueryDeployment(opts))
 	utils.ValidateObjectsEqual(t, objs[2], NewQueryService(opts))
-	if objs[3].GetObjectKind().GroupVersionKind().Kind != "PodDisruptionBudget" {
-		t.Errorf("expected object to be a PodDisruptionBudget, got %v", objs[3].GetObjectKind().GroupVersionKind().Kind)
-	}
-	utils.ValidateLabelsMatch(t, objs[3], objs[1])
+	utils.ValidateIsNamedPodDisruptionBudget(t, objs[3], opts, opts.Namespace, objs[1])
 
 	wantLabels := opts.GetSelectorLabels()
 	wantLabels["some-custom-label"] = someCustomLabelValue

--- a/internal/pkg/manifests/queryfrontend/builder.go
+++ b/internal/pkg/manifests/queryfrontend/builder.go
@@ -58,7 +58,11 @@ func (opts Options) Build() []client.Object {
 	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
 	objs = append(objs, newQueryFrontendDeployment(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newQueryFrontendService(opts, selectorLabels, objectMetaLabels))
-	objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, ptr.To(1)))
+
+	if opts.PodDisruptionConfig != nil {
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+	}
+
 	if opts.ResponseCacheConfig == nil {
 		objs = append(objs, newQueryFrontendInMemoryConfigMap(opts, GetRequiredLabels()))
 	}

--- a/internal/pkg/manifests/queryfrontend/builder_test.go
+++ b/internal/pkg/manifests/queryfrontend/builder_test.go
@@ -29,6 +29,7 @@ func TestBuildQueryFrontend(t *testing.T) {
 				"some-other-label":       someOtherLabelValue,
 				"app.kubernetes.io/name": "expect-to-be-discarded",
 			},
+			PodDisruptionConfig: &manifests.PodDisruptionBudgetOptions{},
 		},
 		QueryService:         "thanos-query",
 		LogQueriesLongerThan: "5s",

--- a/internal/pkg/manifests/ruler/builder.go
+++ b/internal/pkg/manifests/ruler/builder.go
@@ -60,7 +60,10 @@ func (opts Options) Build() []client.Object {
 	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
 	objs = append(objs, newRulerStatefulSet(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newRulerService(opts, selectorLabels, objectMetaLabels))
-	objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, ptr.To(1)))
+
+	if opts.PodDisruptionConfig != nil {
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+	}
 
 	if opts.ServiceMonitorConfig.Enabled {
 		smLabels := manifests.MergeLabels(opts.ServiceMonitorConfig.Labels, objectMetaLabels)

--- a/internal/pkg/manifests/ruler/builder_test.go
+++ b/internal/pkg/manifests/ruler/builder_test.go
@@ -29,6 +29,7 @@ func TestBuildRuler(t *testing.T) {
 				"some-other-label":       someOtherLabelValue,
 				"app.kubernetes.io/name": "expect-to-be-discarded",
 			},
+			PodDisruptionConfig: &manifests.PodDisruptionBudgetOptions{},
 		},
 		Endpoints: []Endpoint{
 			{

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -62,6 +62,11 @@ func (opts Options) Build() []client.Object {
 	if opts.IndexCacheConfig == nil || opts.CachingBucketConfig == nil {
 		objs = append(objs, newStoreInMemoryConfigMap(opts, GetRequiredLabels()))
 	}
+
+	if opts.PodDisruptionConfig != nil {
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+	}
+
 	if opts.ServiceMonitorConfig.Enabled {
 		objs = append(objs, manifests.BuildServiceMonitor(name, opts.Namespace, objectMetaLabels, selectorLabels, serviceMonitorOpts(opts.ServiceMonitorConfig)))
 	}

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -226,7 +226,7 @@ func (v Verifier) WithService() Verifier {
 }
 
 func (v Verifier) WithStatefulSet() Verifier {
-	v.svc = true
+	v.sts = true
 	return v
 }
 
@@ -679,7 +679,7 @@ func ValidateLabelsMatch(t *testing.T, objWithSelector client.Object, matches cl
 	}
 }
 
-func ValidateNameNamespaceAndLabels(t *testing.T, obj client.Object, name, namespace string, labels map[string]string) {
+func ValidateNameAndNamespace(t *testing.T, obj client.Object, name, namespace string) {
 	t.Helper()
 	if obj.GetName() != name {
 		t.Errorf("expected object to have name %s, got %s", name, obj.GetName())
@@ -687,6 +687,11 @@ func ValidateNameNamespaceAndLabels(t *testing.T, obj client.Object, name, names
 	if obj.GetNamespace() != namespace {
 		t.Errorf("expected object to have namespace %s, got %s", namespace, obj.GetNamespace())
 	}
+}
+
+func ValidateNameNamespaceAndLabels(t *testing.T, obj client.Object, name, namespace string, labels map[string]string) {
+	t.Helper()
+	ValidateNameAndNamespace(t, obj, name, namespace)
 	ValidateObjectLabelsEqual(t, labels, obj)
 }
 
@@ -820,4 +825,13 @@ func ValidateIsNamedServiceAccount(t *testing.T, obj client.Object, b manifests.
 	}
 
 	ValidateNameNamespaceAndLabels(t, obj, b.GetGeneratedResourceName(), namespace, b.GetSelectorLabels())
+}
+
+func ValidateIsNamedPodDisruptionBudget(t *testing.T, obj client.Object, b manifests.Buildable, namespace string, matching client.Object) {
+	t.Helper()
+	if obj.GetObjectKind().GroupVersionKind().Kind != "PodDisruptionBudget" {
+		t.Errorf("expected object to be a PodDisruptionBudget, got %v", obj.GetObjectKind().GroupVersionKind().Kind)
+	}
+	ValidateNameAndNamespace(t, obj, b.GetGeneratedResourceName(), namespace)
+	ValidateLabelsMatch(t, obj, matching)
 }


### PR DESCRIPTION
This change adds PodDisruptionBudget management to the remaining components. As of now, we don't expose any additional configuration into the API spec for any of the controllers . The default behaviour is, if a component is deployed with more than a single replica, a PDB is created for that workload with a configuration of MaxUnavailable to 1.

We may push this configuration into user space at some point.

This PR does not include cleanup logic which will be added in another PR