### PR TITLE
Add logic to inherit annotations

### DIFF
--- a/internal/pkg/manifests/compact/builder.go
+++ b/internal/pkg/manifests/compact/builder.go
@@ -61,7 +61,7 @@ func (opts Options) Build() []client.Object {
 	selectorLabels := opts.GetSelectorLabels()
 	objectMetaLabels := manifests.MergeLabels(opts.Labels, selectorLabels)
 
-	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
+	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels, opts.Annotations))
 	objs = append(objs, newShardStatefulSet(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newService(opts, selectorLabels, objectMetaLabels))
 
@@ -132,9 +132,10 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: opts.Namespace,
-			Labels:    metaLabels,
+			Name:        name,
+			Namespace:   opts.Namespace,
+			Labels:      metaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
@@ -251,9 +252,10 @@ func newService(opts Options, selectorLabels, objectMetaLabels map[string]string
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.GetGeneratedResourceName(),
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        opts.GetGeneratedResourceName(),
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: selectorLabels,

--- a/internal/pkg/manifests/compact/builder_test.go
+++ b/internal/pkg/manifests/compact/builder_test.go
@@ -70,6 +70,9 @@ func TestNewStatefulSet(t *testing.T) {
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
+					Annotations: map[string]string{
+						"test": "annotation",
+					},
 				},
 			},
 		},
@@ -84,6 +87,9 @@ func TestNewStatefulSet(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 				},
 			},
@@ -111,6 +117,10 @@ func TestNewStatefulSet(t *testing.T) {
 
 			if len(compact.Spec.Template.Spec.Containers) != (len(tc.opts.Additional.Containers) + 1) {
 				t.Errorf("expected compact statefulset to have %d containers, got %d", len(tc.opts.Additional.Containers)+1, len(compact.Spec.Template.Spec.Containers))
+			}
+
+			if compact.Annotations["test"] != "annotation" {
+				t.Errorf("expected compact statefulset annotation test to be annotation, got %s", compact.Annotations["test"])
 			}
 
 			expectArgs := compactorArgsFrom(tc.opts)

--- a/internal/pkg/manifests/options.go
+++ b/internal/pkg/manifests/options.go
@@ -76,6 +76,8 @@ type Options struct {
 	// The builders should ensure that the default labels are set on the object.
 	// The builders will overwrite the default labels if they are set in the Labels.
 	Labels map[string]string
+	// Annotations is the annotations for the object
+	Annotations map[string]string
 	// Image is the image to use for the component
 	// If not set, DefaultThanosImage will be used
 	Image *string

--- a/internal/pkg/manifests/pdb.go
+++ b/internal/pkg/manifests/pdb.go
@@ -21,7 +21,7 @@ type PodDisruptionBudgetOptions struct {
 // It sets the object name, namespace, selector labels, object meta labels, and maxUnavailable.
 // The maxUnavailable is a pointer to an int32 value.
 // If the maxUnavailable is nil, it defaults to 1.
-func NewPodDisruptionBudget(name, namespace string, selectorLabels, objectMetaLabels map[string]string, opts PodDisruptionBudgetOptions) *policyv1.PodDisruptionBudget {
+func NewPodDisruptionBudget(name, namespace string, selectorLabels, objectMetaLabels, annotations map[string]string, opts PodDisruptionBudgetOptions) *policyv1.PodDisruptionBudget {
 	minValue, maxValue := opts.getMinAndMax()
 	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
@@ -29,9 +29,10 @@ func NewPodDisruptionBudget(name, namespace string, selectorLabels, objectMetaLa
 			APIVersion: policyv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:    objectMetaLabels,
-			Name:      name,
-			Namespace: namespace,
+			Labels:      objectMetaLabels,
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{

--- a/internal/pkg/manifests/pdb_test.go
+++ b/internal/pkg/manifests/pdb_test.go
@@ -10,6 +10,7 @@ func TestNewPodDisruptionBudget(t *testing.T) {
 		namespace        string
 		selectorLabels   map[string]string
 		objectMetaLabels map[string]string
+		annotations      map[string]string
 		conf             PodDisruptionBudgetOptions
 	}
 	tests := []struct {
@@ -23,13 +24,14 @@ func TestNewPodDisruptionBudget(t *testing.T) {
 				namespace:        "test-namespace",
 				selectorLabels:   map[string]string{"test": "label"},
 				objectMetaLabels: map[string]string{"test": "label"},
+				annotations:      map[string]string{"test": "annotation"},
 				conf:             PodDisruptionBudgetOptions{},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pdb := NewPodDisruptionBudget(tt.args.name, tt.args.namespace, tt.args.selectorLabels, tt.args.objectMetaLabels, tt.args.conf)
+			pdb := NewPodDisruptionBudget(tt.args.name, tt.args.namespace, tt.args.selectorLabels, tt.args.objectMetaLabels, tt.args.annotations, tt.args.conf)
 			if pdb.Name != tt.args.name {
 				t.Errorf("pdb.Name = %v, want %v", pdb.Name, tt.args.name)
 			}

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -63,12 +63,12 @@ func (opts Options) Build() []client.Object {
 	objectMetaLabels := GetLabels(opts)
 	name := opts.GetGeneratedResourceName()
 
-	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
+	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels, opts.Annotations))
 	objs = append(objs, newQueryDeployment(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newQueryService(opts, selectorLabels, objectMetaLabels))
 
 	if opts.PodDisruptionConfig != nil {
-		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, opts.Annotations, *opts.PodDisruptionConfig))
 	}
 
 	if opts.ServiceMonitorConfig.Enabled {
@@ -176,9 +176,10 @@ func newQueryDeployment(opts Options, selectorLabels, objectMetaLabels map[strin
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        name,
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &opts.Replicas,
@@ -232,9 +233,10 @@ func newQueryService(opts Options, selectorLabels, objectMetaLabels map[string]s
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.GetGeneratedResourceName(),
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        opts.GetGeneratedResourceName(),
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:  selectorLabels,

--- a/internal/pkg/manifests/query/builder_test.go
+++ b/internal/pkg/manifests/query/builder_test.go
@@ -72,6 +72,9 @@ func TestNewQueryDeployment(t *testing.T) {
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
+					Annotations: map[string]string{
+						"test": "annotation",
+					},
 				},
 				Timeout:       "15m",
 				LookbackDelta: "5m",
@@ -88,6 +91,9 @@ func TestNewQueryDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						VolumeMounts: []corev1.VolumeMount{
@@ -113,6 +119,9 @@ func TestNewQueryDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						Containers: []corev1.Container{
@@ -147,6 +156,12 @@ func TestNewQueryDeployment(t *testing.T) {
 			}
 			if len(query.Spec.Template.Spec.Containers) != (len(tc.opts.Additional.Containers) + 1) {
 				t.Errorf("expected deployment to have %d containers, got %d", len(tc.opts.Additional.Containers)+1, len(query.Spec.Template.Spec.Containers))
+			}
+			if len(query.Annotations) != 1 {
+				t.Errorf("expected deployment to have 1 annotation, got %d", len(query.Annotations))
+			}
+			if query.Annotations["test"] != "annotation" {
+				t.Errorf("expected deployment annotation test to be annotation, got %s", query.Annotations["test"])
 			}
 
 			expectArgs := queryArgs(tc.opts)

--- a/internal/pkg/manifests/queryfrontend/builder.go
+++ b/internal/pkg/manifests/queryfrontend/builder.go
@@ -48,12 +48,12 @@ func (opts Options) Build() []client.Object {
 	objectMetaLabels := GetLabels(opts)
 	name := opts.GetGeneratedResourceName()
 
-	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
+	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels, opts.Annotations))
 	objs = append(objs, newQueryFrontendDeployment(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newQueryFrontendService(opts, selectorLabels, objectMetaLabels))
 
 	if opts.PodDisruptionConfig != nil {
-		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, opts.Annotations, *opts.PodDisruptionConfig))
 	}
 
 	return objs
@@ -95,9 +95,10 @@ func newQueryFrontendDeployment(opts Options, selectorLabels, objectMetaLabels m
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        name,
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &opts.Replicas,
@@ -172,9 +173,10 @@ func newQueryFrontendService(opts Options, selectorLabels, objectMetaLabels map[
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.GetGeneratedResourceName(),
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        opts.GetGeneratedResourceName(),
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{

--- a/internal/pkg/manifests/queryfrontend/builder_test.go
+++ b/internal/pkg/manifests/queryfrontend/builder_test.go
@@ -82,6 +82,9 @@ func TestNewQueryFrontendDeployment(t *testing.T) {
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
+					Annotations: map[string]string{
+						"test": "annotation",
+					},
 					Replicas: 2,
 				},
 				QueryService:         "thanos-query",
@@ -103,6 +106,9 @@ func TestNewQueryFrontendDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Replicas: 2,
 					Additional: manifests.Additional{
@@ -133,6 +139,9 @@ func TestNewQueryFrontendDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Replicas: 2,
 					Additional: manifests.Additional{
@@ -169,6 +178,9 @@ func TestNewQueryFrontendDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Replicas: 2,
 				},
@@ -219,6 +231,10 @@ func TestNewQueryFrontendDeployment(t *testing.T) {
 
 			if *deployment.Spec.Replicas != tc.opts.Replicas {
 				t.Errorf("expected deployment replicas to be %d, got %d", tc.opts.Replicas, *deployment.Spec.Replicas)
+			}
+
+			if deployment.Annotations["test"] != "annotation" {
+				t.Errorf("expected deployment annotation test to be annotation, got %s", deployment.Annotations["test"])
 			}
 
 			// Check containers

--- a/internal/pkg/manifests/receive/builder_test.go
+++ b/internal/pkg/manifests/receive/builder_test.go
@@ -102,6 +102,9 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
+					Annotations: map[string]string{
+						"test": "annotation",
+					},
 				},
 			},
 		},
@@ -115,6 +118,9 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						VolumeMounts: []corev1.VolumeMount{
@@ -137,6 +143,9 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						Containers: []corev1.Container{
@@ -173,6 +182,10 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 
 			if len(ingester.Spec.Template.Spec.Containers) != (len(tc.opts.Additional.Containers) + 1) {
 				t.Errorf("expected ingester statefulset to have %d containers, got %d", len(tc.opts.Additional.Containers)+1, len(ingester.Spec.Template.Spec.Containers))
+			}
+
+			if ingester.Annotations["test"] != "annotation" {
+				t.Errorf("expected ingester statefulset annotation test to be annotation, got %s", ingester.Annotations["test"])
 			}
 
 			expectArgs := ingestorArgsFrom(tc.opts)
@@ -226,6 +239,9 @@ func TestNewRouterDeployment(t *testing.T) {
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
+					Annotations: map[string]string{
+						"test": "annotation",
+					},
 				},
 			},
 		},
@@ -239,6 +255,9 @@ func TestNewRouterDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						VolumeMounts: []corev1.VolumeMount{
@@ -261,6 +280,9 @@ func TestNewRouterDeployment(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						Containers: []corev1.Container{
@@ -292,6 +314,10 @@ func TestNewRouterDeployment(t *testing.T) {
 			}
 			if len(router.Spec.Template.Spec.Containers) != (len(tc.opts.Additional.Containers) + 1) {
 				t.Errorf("expected deployment to have %d containers, got %d", len(tc.opts.Additional.Containers)+1, len(router.Spec.Template.Spec.Containers))
+			}
+
+			if router.Annotations["test"] != "annotation" {
+				t.Errorf("expected router deployment annotation test to be annotation, got %s", router.Annotations["test"])
 			}
 
 			expectArgs := routerArgsFrom(tc.opts)

--- a/internal/pkg/manifests/ruler/builder.go
+++ b/internal/pkg/manifests/ruler/builder.go
@@ -57,12 +57,12 @@ func (opts Options) Build() []client.Object {
 	objectMetaLabels := GetLabels(opts)
 	name := opts.GetGeneratedResourceName()
 
-	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels))
+	objs = append(objs, manifests.BuildServiceAccount(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels, opts.Annotations))
 	objs = append(objs, newRulerStatefulSet(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newRulerService(opts, selectorLabels, objectMetaLabels))
 
 	if opts.PodDisruptionConfig != nil {
-		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, opts.Annotations, *opts.PodDisruptionConfig))
 	}
 
 	if opts.ServiceMonitorConfig.Enabled {
@@ -245,9 +245,10 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        name,
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas:             &opts.Replicas,
@@ -301,9 +302,10 @@ func NewRulerService(opts Options) *corev1.Service {
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.GetGeneratedResourceName(),
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        opts.GetGeneratedResourceName(),
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:  selectorLabels,
@@ -337,9 +339,10 @@ func newRulerService(opts Options, selectorLabels, objectMetaLabels map[string]s
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.GetGeneratedResourceName(),
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        opts.GetGeneratedResourceName(),
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector:  selectorLabels,

--- a/internal/pkg/manifests/ruler/builder_test.go
+++ b/internal/pkg/manifests/ruler/builder_test.go
@@ -100,6 +100,9 @@ func TestNewRulerStatefulSet(t *testing.T) {
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
 					},
+					Annotations: map[string]string{
+						"test": "annotation",
+					},
 				},
 				Endpoints: []Endpoint{
 					{
@@ -139,6 +142,9 @@ func TestNewRulerStatefulSet(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						VolumeMounts: []corev1.VolumeMount{
@@ -187,6 +193,9 @@ func TestNewRulerStatefulSet(t *testing.T) {
 						"some-custom-label":      someCustomLabelValue,
 						"some-other-label":       someOtherLabelValue,
 						"app.kubernetes.io/name": "expect-to-be-discarded",
+					},
+					Annotations: map[string]string{
+						"test": "annotation",
 					},
 					Additional: manifests.Additional{
 						Containers: []corev1.Container{
@@ -249,6 +258,10 @@ func TestNewRulerStatefulSet(t *testing.T) {
 
 			if len(ruler.Spec.Template.Spec.Containers) != (len(tc.opts.Additional.Containers) + 1) {
 				t.Errorf("expected ruler statefulset to have %d containers, got %d", len(tc.opts.Additional.Containers)+1, len(ruler.Spec.Template.Spec.Containers))
+			}
+
+			if ruler.Annotations["test"] != "annotation" {
+				t.Errorf("expected ruler statefulset annotation test to be annotation, got %s", ruler.Annotations["test"])
 			}
 
 			expectArgs := rulerArgs(tc.opts)

--- a/internal/pkg/manifests/service_account.go
+++ b/internal/pkg/manifests/service_account.go
@@ -9,16 +9,17 @@ import (
 )
 
 // BuildServiceAccount returns a new ServiceAccount from Options.
-func BuildServiceAccount(name, namespace string, labels map[string]string) client.Object {
+func BuildServiceAccount(name, namespace string, labels, annotations map[string]string) client.Object {
 	return &corev1.ServiceAccount{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ServiceAccount",
 			APIVersion: corev1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		AutomountServiceAccountToken: ptr.To(true),
 	}

--- a/internal/pkg/manifests/service_account_test.go
+++ b/internal/pkg/manifests/service_account_test.go
@@ -12,6 +12,9 @@ func TestBuildServiceAccount(t *testing.T) {
 			"app.kubernetes.io/name":     "thanos",
 			"app.kubernetes.io/instance": "thanos-stack",
 		},
+		Annotations: map[string]string{
+			"test": "annotation",
+		},
 	}
 
 	for _, tc := range []struct {
@@ -24,7 +27,7 @@ func TestBuildServiceAccount(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			sa := BuildServiceAccount(name, tc.opts.Namespace, tc.opts.Labels)
+			sa := BuildServiceAccount(name, tc.opts.Namespace, tc.opts.Labels, tc.opts.Annotations)
 			if sa.GetName() != name {
 				t.Errorf("expected service account name to be %s, got %s", name, sa.GetName())
 			}
@@ -39,6 +42,12 @@ func TestBuildServiceAccount(t *testing.T) {
 			}
 			if sa.GetLabels()["app.kubernetes.io/instance"] != "thanos-stack" {
 				t.Errorf("expected service account label app.kubernetes.io/instance to be thanos-stack, got %s", sa.GetLabels()["app.kubernetes.io/instance"])
+			}
+			if len(sa.GetAnnotations()) != 1 {
+				t.Errorf("expected service account to have 1 annotation, got %d", len(sa.GetAnnotations()))
+			}
+			if sa.GetAnnotations()["test"] != "annotation" {
+				t.Errorf("expected service account annotation test to be annotation, got %s", sa.GetAnnotations()["test"])
 			}
 		})
 	}

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -53,12 +53,12 @@ func (opts Options) Build() []client.Object {
 	objectMetaLabels := GetLabels(opts)
 	name := opts.GetGeneratedResourceName()
 
-	objs = append(objs, manifests.BuildServiceAccount(name, opts.Namespace, selectorLabels))
+	objs = append(objs, manifests.BuildServiceAccount(name, opts.Namespace, selectorLabels, opts.Annotations))
 	objs = append(objs, newStoreService(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newStoreShardStatefulSet(opts, selectorLabels, objectMetaLabels))
 
 	if opts.PodDisruptionConfig != nil {
-		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, *opts.PodDisruptionConfig))
+		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, opts.Annotations, *opts.PodDisruptionConfig))
 	}
 
 	if opts.ServiceMonitorConfig.Enabled {
@@ -168,9 +168,10 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        name,
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: name,
@@ -294,9 +295,10 @@ func newService(opts Options, selectorLabels, objectMetaLabels map[string]string
 			Kind: "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      opts.GetGeneratedResourceName(),
-			Namespace: opts.Namespace,
-			Labels:    objectMetaLabels,
+			Name:        opts.GetGeneratedResourceName(),
+			Namespace:   opts.Namespace,
+			Labels:      objectMetaLabels,
+			Annotations: opts.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: selectorLabels,

--- a/internal/pkg/manifests/store/builder_test.go
+++ b/internal/pkg/manifests/store/builder_test.go
@@ -71,6 +71,9 @@ func TestNewStoreStatefulSet(t *testing.T) {
 					"some-other-label":        someOtherLabelValue,
 					"app.kubernetes.io/owner": "expect-to-be-discarded",
 				},
+				Annotations: map[string]string{
+					"test": "annotation",
+				},
 			},
 		}
 	}
@@ -138,6 +141,10 @@ func TestNewStoreStatefulSet(t *testing.T) {
 
 			if len(store.Spec.Template.Spec.Containers) != (len(builtOpts.Additional.Containers) + 1) {
 				t.Errorf("expected store statefulset to have %d containers, got %d", len(builtOpts.Additional.Containers)+1, len(store.Spec.Template.Spec.Containers))
+			}
+
+			if store.Annotations["test"] != "annotation" {
+				t.Errorf("expected store statefulset annotation test to be annotation, got %s", store.Annotations["test"])
 			}
 
 			expectArgs := storeArgsFrom(builtOpts)


### PR DESCRIPTION
This commit allows inheriting annotations set on CRDs, indiscriminately to all built resources.
Skips over service monitors for now

Fixes #122 