### PR TITLE
ctrl:query: Sort list of endpoints by Service name

### DIFF
--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -216,6 +217,9 @@ func (r *ThanosQueryReconciler) getStoreAPIServiceEndpoints(ctx context.Context,
 		r.metrics.EndpointsConfigured.WithLabelValues(string(etype), query.GetName(), query.GetNamespace()).Inc()
 	}
 
+	sort.Slice(endpoints, func(i, j int) bool {
+		return endpoints[i].ServiceName < endpoints[j].ServiceName
+	})
 	return endpoints, nil
 }
 


### PR DESCRIPTION
This is required to avoid the churning on query reconciliations 

Fixes #171 

<img width="1899" alt="image" src="https://github.com/user-attachments/assets/fe35a775-d8cf-4f9a-9177-40908e264418">
