### PR TITLE
Add validity check to builder interface

### DIFF
--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -50,7 +50,11 @@ func queryV1Alpha1ToOptions(in v1alpha1.ThanosQuery) manifestquery.Options {
 
 // QueryNameFromParent returns the name of the Thanos Query component.
 func QueryNameFromParent(resourceName string) string {
-	return manifestquery.Options{Options: manifests.Options{Owner: resourceName}}.GetGeneratedResourceName()
+	opts := manifestquery.Options{Options: manifests.Options{Owner: resourceName}}
+	if err := opts.Valid(); err != nil {
+		panic("invalid query options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 // queryV1Alpha1ToQueryFrontEndOptions transforms a v1alpha1.ThanosQuery to a build Options
@@ -77,7 +81,11 @@ func queryV1Alpha1ToQueryFrontEndOptions(in v1alpha1.ThanosQuery) manifestqueryf
 
 // QueryFrontendNameFromParent returns the name of the Thanos Query Frontend component.
 func QueryFrontendNameFromParent(resourceName string) string {
-	return manifestqueryfrontend.Options{Options: manifests.Options{Owner: resourceName}}.GetGeneratedResourceName()
+	opts := manifestqueryfrontend.Options{Options: manifests.Options{Owner: resourceName}}
+	if err := opts.Valid(); err != nil {
+		panic("invalid query frontend options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 func rulerV1Alpha1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
@@ -97,7 +105,11 @@ func rulerV1Alpha1ToOptions(in v1alpha1.ThanosRuler) manifestruler.Options {
 
 // RulerNameFromParent returns the name of the Thanos Ruler component.
 func RulerNameFromParent(resourceName string) string {
-	return manifestruler.Options{Options: manifests.Options{Owner: resourceName}}.GetGeneratedResourceName()
+	opts := manifestruler.Options{Options: manifests.Options{Owner: resourceName}}
+	if err := opts.Valid(); err != nil {
+		panic("invalid ruler options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 func receiverV1Alpha1ToIngesterOptions(in v1alpha1.ThanosReceive, spec v1alpha1.IngesterHashringSpec) manifestreceive.IngesterOptions {
@@ -156,12 +168,20 @@ func receiverV1Alpha1ToRouterOptions(in v1alpha1.ThanosReceive) manifestreceive.
 
 // ReceiveIngesterNameFromParent returns the name of the Thanos Receive Ingester component.
 func ReceiveIngesterNameFromParent(resourceName, hashringName string) string {
-	return manifestreceive.IngesterOptions{Options: manifests.Options{Owner: resourceName}, HashringName: hashringName}.GetGeneratedResourceName()
+	opts := manifestreceive.IngesterOptions{Options: manifests.Options{Owner: resourceName}, HashringName: hashringName}
+	if err := opts.Valid(); err != nil {
+		panic("invalid ingester options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 // ReceiveRouterNameFromParent returns the name of the Thanos Receive Router component.
 func ReceiveRouterNameFromParent(resourceName string) string {
-	return manifestreceive.RouterOptions{Options: manifests.Options{Owner: resourceName}}.GetGeneratedResourceName()
+	opts := manifestreceive.RouterOptions{Options: manifests.Options{Owner: resourceName}}
+	if err := opts.Valid(); err != nil {
+		panic("invalid router options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 func storeV1Alpha1ToOptions(in v1alpha1.ThanosStore) manifestsstore.Options {
@@ -278,12 +298,20 @@ func compactV1Alpha1ToOptions(in v1alpha1.ThanosCompact) manifestscompact.Option
 
 // CompactNameFromParent returns the name of the Thanos Compact component.
 func CompactNameFromParent(resourceName string) string {
-	return manifestscompact.Options{Options: manifests.Options{Owner: resourceName}}.GetGeneratedResourceName()
+	opts := manifestscompact.Options{Options: manifests.Options{Owner: resourceName}}
+	if err := opts.Valid(); err != nil {
+		panic("invalid compact options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 // StoreNameFromParent returns the name of the Thanos Store component.
 func StoreNameFromParent(resourceName string, index *int32) string {
-	return manifestsstore.Options{Options: manifests.Options{Owner: resourceName}, ShardIndex: index}.GetGeneratedResourceName()
+	opts := manifestsstore.Options{Options: manifests.Options{Owner: resourceName}, ShardIndex: index}
+	if err := opts.Valid(); err != nil {
+		panic("invalid store options")
+	}
+	return opts.GetGeneratedResourceName()
 }
 
 func commonToOpts(

--- a/internal/pkg/manifests/compact/builder.go
+++ b/internal/pkg/manifests/compact/builder.go
@@ -74,6 +74,13 @@ func (opts Options) Build() []client.Object {
 	return objs
 }
 
+func (opts Options) Valid() error {
+	if opts.getOwner() == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	return nil
+}
+
 // GetGeneratedResourceName returns the generated name for the Thanos Compact or shard.
 // If no sharding is configured, the name will be generated from the Options.Owner.
 // If sharding is configured, the name will be generated from the Options.Owner, ShardName, and ShardIndex.

--- a/internal/pkg/manifests/options.go
+++ b/internal/pkg/manifests/options.go
@@ -39,6 +39,8 @@ type Buildable interface {
 	// - InstanceLabel
 	// - OwnerLabel
 	GetSelectorLabels() map[string]string
+	// Valid returns an error if the object is not valid.
+	Valid() error
 }
 
 // GetLabelSelectorForOwner is a convenience function to enable building a ListOption for the Owner label.

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -83,6 +83,13 @@ func (opts Options) Build() []client.Object {
 	return objs
 }
 
+func (opts Options) Valid() error {
+	if opts.getOwner() == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	return nil
+}
+
 func (opts Options) GetGeneratedResourceName() string {
 	name := fmt.Sprintf("%s-%s", Name, opts.getOwner())
 	return manifests.ValidateAndSanitizeResourceName(name)

--- a/internal/pkg/manifests/queryfrontend/builder.go
+++ b/internal/pkg/manifests/queryfrontend/builder.go
@@ -59,6 +59,13 @@ func (opts Options) Build() []client.Object {
 	return objs
 }
 
+func (opts Options) Valid() error {
+	if opts.getOwner() == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	return nil
+}
+
 func (opts Options) GetGeneratedResourceName() string {
 	name := fmt.Sprintf("%s-%s", Name, opts.getOwner())
 	return manifests.ValidateAndSanitizeResourceName(name)

--- a/internal/pkg/manifests/receive/builder.go
+++ b/internal/pkg/manifests/receive/builder.go
@@ -102,6 +102,16 @@ func (opts IngesterOptions) Build() []client.Object {
 	return objs
 }
 
+func (opts IngesterOptions) Valid() error {
+	if opts.Owner == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	if opts.HashringName == "" {
+		return fmt.Errorf("hashring name cannot be empty")
+	}
+	return nil
+}
+
 func (opts IngesterOptions) GetGeneratedResourceName() string {
 	name := fmt.Sprintf("%s-%s-%s", IngestComponentName, opts.Owner, opts.HashringName)
 	return manifests.ValidateAndSanitizeResourceName(name)
@@ -127,6 +137,13 @@ func (opts RouterOptions) Build() []client.Object {
 		objs = append(objs, manifests.BuildServiceMonitor(name, opts.Namespace, objectMetaLabels, selectorLabels, serviceMonitorOpts(opts.ServiceMonitorConfig)))
 	}
 	return objs
+}
+
+func (opts RouterOptions) Valid() error {
+	if opts.Owner == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	return nil
 }
 
 func (opts RouterOptions) GetGeneratedResourceName() string {

--- a/internal/pkg/manifests/ruler/builder.go
+++ b/internal/pkg/manifests/ruler/builder.go
@@ -77,6 +77,13 @@ func (opts Options) Build() []client.Object {
 	return objs
 }
 
+func (opts Options) Valid() error {
+	if opts.Owner == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	return nil
+}
+
 func (opts Options) GetGeneratedResourceName() string {
 	name := fmt.Sprintf("%s-%s", Name, opts.Owner)
 	return manifests.ValidateAndSanitizeResourceName(name)

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -76,6 +76,13 @@ func (opts Options) Build() []client.Object {
 	return objs
 }
 
+func (opts Options) Valid() error {
+	if opts.Owner == "" {
+		return fmt.Errorf("owner cannot be empty")
+	}
+	return nil
+}
+
 // GetGeneratedResourceName returns the name of the Thanos Store component.
 // If a shard index is provided, the name will be suffixed with the shard index.
 func (opts Options) GetGeneratedResourceName() string {


### PR DESCRIPTION
Allows the caller to check if the options passed to the underlying implementation are valid