### PR TITLE
Allow auto-merging dependabot PRs

### DIFF
--- a/.github/workflows/automerge-dependabot.yaml
+++ b/.github/workflows/automerge-dependabot.yaml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ (github.event.pull_request && github.event.pull_request.number) || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v2.3.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This ports over an auto-merge workflow for dependabot PRs from [client_golang](https://github.com/prometheus/client_golang/blob/main/.github/workflows/automerge-dependabot.yml). The idea is to reduce open dep bump PRs.

I think we need to mark the tests as required (which is there already)