### PR TITLE
fix maxCompactionLevel for compact debug config

### DIFF
--- a/api/v1alpha1/thanoscompact_types.go
+++ b/api/v1alpha1/thanoscompact_types.go
@@ -125,7 +125,8 @@ type DebugConfig struct {
 	// +kubebuilder:validation:Optional
 	AcceptMalformedIndex *bool `json:"acceptMalformedIndex,omitempty"`
 	// MaxCompactionLevel is the maximum compaction level to use when compacting blocks.
-	// +kubebuilder:default=5
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=4
 	// +kubebuilder:validation:Optional
 	MaxCompactionLevel *int32 `json:"maxCompactionLevel,omitempty"`
 	// HaltOnError halts the compact process on critical compaction error.

--- a/config/crd/bases/monitoring.thanos.io_thanoscompacts.yaml
+++ b/config/crd/bases/monitoring.thanos.io_thanoscompacts.yaml
@@ -4568,10 +4568,11 @@ spec:
                       compaction error.
                     type: boolean
                   maxCompactionLevel:
-                    default: 5
                     description: MaxCompactionLevel is the maximum compaction level
                       to use when compacting blocks.
                     format: int32
+                    maximum: 4
+                    minimum: 0
                     type: integer
                 type: object
               downsamplingConfig:

--- a/docs/api.md
+++ b/docs/api.md
@@ -187,7 +187,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `acceptMalformedIndex` _boolean_ | AcceptMalformedIndex allows compact to accept blocks with malformed index. | false | Optional: \{\} <br /> |
-| `maxCompactionLevel` _integer_ | MaxCompactionLevel is the maximum compaction level to use when compacting blocks. | 5 | Optional: \{\} <br /> |
+| `maxCompactionLevel` _integer_ | MaxCompactionLevel is the maximum compaction level to use when compacting blocks. |  | Maximum: 4 <br />Minimum: 0 <br />Optional: \{\} <br /> |
 | `haltOnError` _boolean_ | HaltOnError halts the compact process on critical compaction error. | false | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
Related to https://github.com/thanos-io/thanos/pull/578 - the default value of 5 causes compactor not to start if set.