### PR TITLE
Fix outdated json tag on compact CRD

### DIFF
--- a/api/v1alpha1/thanoscompact_types.go
+++ b/api/v1alpha1/thanoscompact_types.go
@@ -141,7 +141,7 @@ type DebugConfig struct {
 type DownsamplingConfig struct {
 	// Disable downsampling.
 	// +kubebuilder:default=false
-	Disable *bool `json:"downsamplingEnabled,omitempty"`
+	Disable *bool `json:"disable,omitempty"`
 	// Concurrency is the number of goroutines to use when downsampling blocks.
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/monitoring.thanos.io_thanoscompacts.yaml
+++ b/config/crd/bases/monitoring.thanos.io_thanoscompacts.yaml
@@ -4579,16 +4579,16 @@ spec:
                 description: DownsamplingConfig is the downsampling configuration
                   for the compact component.
                 properties:
+                  disable:
+                    default: false
+                    description: Disable downsampling.
+                    type: boolean
                   downsamplingConcurrency:
                     default: 1
                     description: Concurrency is the number of goroutines to use when
                       downsampling blocks.
                     format: int32
                     type: integer
-                  downsamplingEnabled:
-                    default: false
-                    description: Disable downsampling.
-                    type: boolean
                 type: object
               featureGates:
                 default:

--- a/docs/api.md
+++ b/docs/api.md
@@ -204,7 +204,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `downsamplingEnabled` _boolean_ | Disable downsampling. | false |  |
+| `disable` _boolean_ | Disable downsampling. | false |  |
 | `downsamplingConcurrency` _integer_ | Concurrency is the number of goroutines to use when downsampling blocks. | 1 | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
This commit updates the downsamplingEnabled to disable tag Fixes https://github.com/thanos-community/thanos-operator/issues/262