### PR TITLE
Stop endless transparent retries in receive forwarding during rollout

### DIFF
--- a/internal/pkg/manifests/options.go
+++ b/internal/pkg/manifests/options.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	DefaultThanosImage   = "quay.io/thanos/thanos"
-	DefaultThanosVersion = "v0.35.1"
+	DefaultThanosVersion = "v0.38.0"
 
 	defaultLogLevel  = "info"
 	defaultLogFormat = "logfmt"

--- a/internal/pkg/manifests/receive/builder.go
+++ b/internal/pkg/manifests/receive/builder.go
@@ -592,6 +592,19 @@ func ingestorArgsFrom(opts IngesterOptions) []string {
 func routerArgsFrom(opts RouterOptions) []string {
 	args := []string{"receive"}
 	args = append(args, opts.ToFlags()...)
+
+	grpcDisableEndlessRetry := `{
+  "loadBalancingPolicy":"round_robin",
+  "retryPolicy": {
+    "maxAttempts": 2,
+    "initialBackoff": "0.1s",
+    "backoffMultiplier": 1,
+    "retryableStatusCodes": [
+  	  "UNAVAILABLE"
+    ]
+  }
+}`
+
 	args = append(args,
 		fmt.Sprintf("--grpc-address=0.0.0.0:%d", GRPCPort),
 		fmt.Sprintf("--http-address=0.0.0.0:%d", HTTPPort),
@@ -599,6 +612,7 @@ func routerArgsFrom(opts RouterOptions) []string {
 		fmt.Sprintf("--receive.replication-factor=%d", opts.ReplicationFactor),
 		fmt.Sprintf("--receive.hashrings-algorithm=%s", opts.HashringAlgorithm),
 		fmt.Sprintf("--receive.hashrings-file=%s/%s", hashringMountPath, HashringConfigKey),
+		fmt.Sprintf("--receive.grpc-service-config=%s", grpcDisableEndlessRetry),
 	)
 	for k, v := range opts.ExternalLabels {
 		args = append(args, fmt.Sprintf(`--label=%s="%s"`, k, v))

--- a/internal/pkg/manifests/testdata/deployment-basic.golden.json
+++ b/internal/pkg/manifests/testdata/deployment-basic.golden.json
@@ -23,7 +23,7 @@
         "containers": [
           {
             "name": "thanos",
-            "image": "quay.io/thanos/thanos:v0.35.1",
+            "image": "quay.io/thanos/thanos:v0.38.0",
             "args": [
               "query",
               "--log.level=info"

--- a/internal/pkg/manifests/testdata/deployment-complete.golden.json
+++ b/internal/pkg/manifests/testdata/deployment-complete.golden.json
@@ -31,7 +31,7 @@
         "containers": [
           {
             "name": "thanos",
-            "image": "quay.io/thanos/thanos:v0.35.1",
+            "image": "quay.io/thanos/thanos:v0.38.0",
             "args": [
               "query",
               "--log.level=info"

--- a/internal/pkg/manifests/testdata/statefulset-basic.golden.json
+++ b/internal/pkg/manifests/testdata/statefulset-basic.golden.json
@@ -23,7 +23,7 @@
         "containers": [
           {
             "name": "thanos",
-            "image": "quay.io/thanos/thanos:v0.35.1",
+            "image": "quay.io/thanos/thanos:v0.38.0",
             "args": [
               "store",
               "--log.level=info"

--- a/internal/pkg/manifests/testdata/statefulset-complete.golden.json
+++ b/internal/pkg/manifests/testdata/statefulset-complete.golden.json
@@ -31,7 +31,7 @@
         "containers": [
           {
             "name": "thanos",
-            "image": "quay.io/thanos/thanos:v0.35.1",
+            "image": "quay.io/thanos/thanos:v0.38.0",
             "args": [
               "store",
               "--log.level=info"


### PR DESCRIPTION
Full discussion on this https://cloud-native.slack.com/archives/CK5RSSC10/p1712830449625329

This became available in 0.38.0 and for now, I'd suggest we don't expose it to the end user at all.