### PR TITLE
fix(ruler): support cm with multiple keys

### DIFF
--- a/internal/pkg/manifests/ruler/builder.go
+++ b/internal/pkg/manifests/ruler/builder.go
@@ -3,6 +3,7 @@ package ruler
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -134,7 +135,7 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 	for _, ruleFile := range opts.RuleFiles {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      ruleFile.Name,
-			MountPath: fmt.Sprintf("/etc/thanos/rules/%s", ruleFile.Key),
+			MountPath: fmt.Sprintf("/etc/thanos/rules/%s/%s", ruleFile.Name, ruleFile.Key),
 			SubPath:   ruleFile.Key,
 		})
 	}
@@ -241,6 +242,9 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 
 	volumes := []corev1.Volume{}
 	for _, ruleFile := range opts.RuleFiles {
+		if slices.ContainsFunc(volumes, func(v corev1.Volume) bool { return v.Name == ruleFile.Name }) {
+			continue
+		}
 		volumes = append(volumes, corev1.Volume{
 			Name: ruleFile.Name,
 			VolumeSource: corev1.VolumeSource{
@@ -389,7 +393,7 @@ func rulerArgs(opts Options) []string {
 	}
 
 	for _, ruleFile := range opts.RuleFiles {
-		args = append(args, fmt.Sprintf("--rule-file=%s", fmt.Sprintf("/etc/thanos/rules/%s", ruleFile.Key)))
+		args = append(args, fmt.Sprintf("--rule-file=%s", fmt.Sprintf("/etc/thanos/rules/%s/%s", ruleFile.Name, ruleFile.Key)))
 	}
 
 	for _, endpoint := range opts.Endpoints {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -710,7 +710,7 @@ var _ = Describe("controller", Ordered, func() {
 						statefulSetName,
 						namespace,
 						0,
-						"--rule-file=/etc/thanos/rules/my-rules.yaml",
+						"--rule-file=/etc/thanos/rules/"+cfgmap.GetName()+"/my-rules.yaml",
 					)
 				}, time.Minute*1, time.Second*10).Should(BeTrue())
 
@@ -719,7 +719,7 @@ var _ = Describe("controller", Ordered, func() {
 						statefulSetName,
 						namespace,
 						0,
-						"--rule-file=/etc/thanos/rules/"+promRule.Name+".yaml",
+						"--rule-file=/etc/thanos/rules/"+cr.GetName()+"-promrule-0/"+promRule.Name+".yaml",
 					)
 				}, time.Minute*1, time.Second*10).Should(BeTrue())
 			})


### PR DESCRIPTION
Quickfix for an infinite reconciliation loop

Currently, when a configuration map (generated by the operator from a Prometheus rule or provided directly to the operator) contains multiple keys, the operator performs an infinite reconciliation.

A better solution would be to mount the config maps directly, use a pattern in `--rule-file` and reload the ruler (sighup or http request) when a configmap is modified (like it's done in the prometheus operator)
