### PR TITLE
query: Fix endpoint gauge metric

### DIFF
--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -221,6 +221,7 @@ func (r *ThanosQueryReconciler) getStoreAPIServiceEndpoints(ctx context.Context,
 		return []manifestquery.Endpoint{}, nil
 	}
 
+	endpointCountByType := make(map[manifests.EndpointType]int)
 	endpoints := make([]manifestquery.Endpoint, len(services.Items))
 	for i, svc := range services.Items {
 
@@ -241,7 +242,11 @@ func (r *ThanosQueryReconciler) getStoreAPIServiceEndpoints(ctx context.Context,
 			Namespace:   svc.GetNamespace(),
 			Type:        etype,
 		}
-		r.metrics.EndpointsConfigured.WithLabelValues(string(etype), query.GetName(), query.GetNamespace()).Inc()
+		endpointCountByType[etype]++
+	}
+
+	for etype, count := range endpointCountByType {
+		r.metrics.EndpointsConfigured.WithLabelValues(string(etype), query.GetName(), query.GetNamespace()).Set(float64(count))
 	}
 
 	sort.Slice(endpoints, func(i, j int) bool {


### PR DESCRIPTION
This commit ensures `thanos_operator_query_endpoints_configured` gauge metric is not incremented, but set on every call to lookup StoreAPIs.