### PR TITLE
e2e: verify recording rules can be queried

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -737,6 +737,8 @@ var _ = Describe("controller", Ordered, func() {
           severity: critical
         annotations:
           summary: High request rate
+      - record: example_recording_rule
+        expr: vector(1)
 `,
 					},
 				}
@@ -791,6 +793,23 @@ var _ = Describe("controller", Ordered, func() {
 						"--rule-file=/etc/thanos/rules/"+cr.GetName()+"-promrule-0/"+promRule.Name+".yaml",
 					)
 				}, time.Minute*3, time.Second*1).Should(BeTrue())
+			})
+
+			It("should allow querying of evaluated rules", func() {
+				cancelFn, err := utils.SetupQueryPortForward(c, namespace)
+				Expect(err).To(BeNil())
+				defer cancelFn()
+
+				Eventually(func() error {
+					resp, err := utils.QueryPrometheus(`example_recording_rule`)
+					if err != nil {
+						return err
+					}
+					if len(resp.Data.Result) == 0 {
+						return fmt.Errorf("no results found for recording rule")
+					}
+					return nil
+				}, time.Minute*3, time.Second*1).Should(BeNil())
 			})
 		})
 	})

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -902,3 +902,27 @@ func VerifyAnnotations(c client.Client, objs []client.Object, name, namespace st
 	}
 	return true
 }
+
+func SetupQueryPortForward(c client.Client, ns string) (context.CancelFunc, error) {
+	ctx := context.Background()
+	selector := client.MatchingLabels{
+		manifests.ComponentLabel: "query-layer",
+	}
+	queryPods := &corev1.PodList{}
+	if err := c.List(ctx, queryPods, selector, &client.ListOptions{Namespace: ns}); err != nil {
+		return nil, err
+	}
+	if len(queryPods.Items) == 0 {
+		return nil, fmt.Errorf("expected at least one pod found in %s namespace", ns)
+	}
+
+	pod := queryPods.Items[0].Name
+	port := intstr.IntOrString{IntVal: 9090}
+	cancelFn, err := StartPortForward(ctx, port, "https", pod, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	return cancelFn, nil
+
+}


### PR DESCRIPTION
Adds helper function that sets up port forwarding for a Thanos Query component and verifies recording rules can be queried in e2e test.