### PR TITLE
feat: Volume expansion controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Thanos Operator binary CLI Options include,
 ```bash mdox-exec="./bin/manager --help"
 Usage of ./bin/manager:
   -enable-feature value
-    	Experimental feature to enable. Repeat for multiple features. Available features: service-monitor, prometheus-rule, kube-resource-sync, otel-sidecar.
+    	Experimental feature to enable. Repeat for multiple features. Available features: service-monitor, prometheus-rule, kube-resource-sync, otel-sidecar, volume-resize.
   -enable-http2
     	If set, HTTP/2 will be enabled for the metrics and webhook servers
   -health-probe-bind-address string

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -39661,6 +39661,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - persistentvolumeclaims
   - secrets
   - serviceaccounts
   - services

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -422,6 +422,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = controller.NewVolumeResizeReconciler(
+		buildConfig("volume-resize"),
+		mgr.GetClient(),
+		mgr.GetScheme(),
+	).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VolumeResize")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -349,6 +349,9 @@ func main() {
 		}
 		commonMetrics.FeatureGatesInfo.WithLabelValues(featuregate.KubeResourceSync).Set(1)
 	}
+	if featureGateConfig.VolumeResizeEnabled() {
+		commonMetrics.FeatureGatesInfo.WithLabelValues(featuregate.VolumeResize).Set(1)
+	}
 
 	configReloaderImage := defaultConfigReloaderImage
 	if image, ok := os.LookupEnv("CONFIG_RELOADER_IMAGE"); ok {
@@ -422,13 +425,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = controller.NewVolumeResizeReconciler(
-		buildConfig("volume-resize"),
-		mgr.GetClient(),
-		mgr.GetScheme(),
-	).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "VolumeResize")
-		os.Exit(1)
+	if featureGateConfig.VolumeResizeEnabled() {
+		if err = controller.NewVolumeResizeReconciler(
+			buildConfig("volume-resize"),
+			mgr.GetClient(),
+			mgr.GetScheme(),
+		).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "VolumeResize")
+			os.Exit(1)
+		}
+		setupLog.Info("VolumeResize controller enabled")
 	}
 
 	//+kubebuilder:scaffold:builder

--- a/config/operator.go
+++ b/config/operator.go
@@ -311,6 +311,17 @@ func WithOtelSidecar() DeploymentOption {
 	}
 }
 
+// WithVolumeResize enables the volume resize controller feature.
+// When enabled, the controller will automatically monitor StatefulSets
+// created by the thanos-operator and resize PersistentVolumeClaims when
+// the storage annotation indicates a size increase. The controller will
+// orphan and recreate StatefulSets when necessary to apply storage changes.
+func WithVolumeResize() DeploymentOption {
+	return func(c *deploymentConfig) {
+		c.featureGate.EnableVolumeResize = true
+	}
+}
+
 // WithFeatures enables multiple specific features at once.
 // Accepts feature names as defined in the featuregate package.
 //
@@ -319,10 +330,11 @@ func WithOtelSidecar() DeploymentOption {
 //   - "prometheus-rule": Enables PrometheusRule discovery
 //   - "kube-resource-sync": Enables kube-resource-sync sidecar
 //   - "otel-sidecar": Enables OpenTelemetry sidecar injection
+//   - "volume-resize": Enables volume resize controller
 //
 // Example:
 //
-//	WithFeatures("service-monitor", "prometheus-rule", "kube-resource-sync", "otel-sidecar")
+//	WithFeatures("service-monitor", "prometheus-rule", "kube-resource-sync", "otel-sidecar", "volume-resize")
 func WithFeatures(features ...string) DeploymentOption {
 	return func(c *deploymentConfig) {
 		for _, feature := range features {
@@ -335,6 +347,8 @@ func WithFeatures(features ...string) DeploymentOption {
 				c.featureGate.EnableOtelSidecar = true
 			case featuregate.KubeResourceSync:
 				c.featureGate.EnableKubeResourceSync = true
+			case featuregate.VolumeResize:
+				c.featureGate.EnableVolumeResize = true
 			}
 		}
 	}
@@ -470,6 +484,9 @@ func buildManagerArgs(featureGate featuregate.Config) []string {
 	}
 	if featureGate.EnableOtelSidecar {
 		args = append(args, "--enable-feature="+featuregate.OtelSidecar)
+	}
+	if featureGate.EnableVolumeResize {
+		args = append(args, "--enable-feature="+featuregate.VolumeResize)
 	}
 
 	return args

--- a/config/operator_test.go
+++ b/config/operator_test.go
@@ -38,6 +38,11 @@ func TestControllerManagerDeployment(t *testing.T) {
 			golden: "deployment-with-features-helper.golden.yaml",
 			opts:   []DeploymentOption{WithFeatures("service-monitor", "prometheus-rule")},
 		},
+		{
+			name:   "deployment with volume resize enabled",
+			golden: "deployment-volume-resize.golden.yaml",
+			opts:   []DeploymentOption{WithVolumeResize()},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			deployment := ControllerManagerDeployment(tc.opts...)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,8 +8,8 @@ rules:
   - ""
   resources:
   - configmaps
-  - secrets
   - persistentvolumeclaims
+  - secrets
   - serviceaccounts
   - services
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - configmaps
   - secrets
+  - persistentvolumeclaims
   - serviceaccounts
   - services
   verbs:

--- a/config/testdata/deployment-volume-resize.golden.yaml
+++ b/config/testdata/deployment-volume-resize.golden.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: thanos-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: thanos-operator
+    control-plane: controller-manager
+  name: controller-manager
+  namespace: system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-secure
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --log.format=logfmt
+        - --log.level=debug
+        - --enable-feature=volume-resize
+        command:
+        - /manager
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+status: {}

--- a/docs/guides/gated-features.md
+++ b/docs/guides/gated-features.md
@@ -342,15 +342,6 @@ thanos_operator_volume_resize_failures_total{statefulset="thanos-store"}
 
 - **Expansion Only**: Volumes can only be expanded, not shrunk
 - **StorageClass Support**: Requires `allowVolumeExpansion: true` in the StorageClass
-- **Downtime**: StatefulSet recreation causes brief downtime during resize
-- **Filesystem Expansion**: Some filesystems may require manual expansion after PVC resize
-
-### Use Cases
-
-- **Growing Data**: Expanding storage as Thanos data retention grows
-- **Performance Scaling**: Increasing volume size for higher IOPS requirements
-- **Capacity Planning**: Proactive storage expansion based on usage forecasts
-- **Emergency Expansion**: Quick storage increases during unexpected data growth
 
 ---
 

--- a/docs/guides/gated-features.md
+++ b/docs/guides/gated-features.md
@@ -18,6 +18,7 @@ Feature gates allow you to:
 | [PrometheusRule](#prometheusrule-feature)               | `prometheus-rule`    | Experimental | Automatic discovery and mounting of PrometheusRule objects        |
 | [OpenTelemetry Sidecar](#opentelemetry-sidecar-feature) | `otel-sidecar`       | Experimental | OpenTelemetry collector sidecar injection for distributed tracing |
 | [KubeResourceSync](#kuberesourcesync-feature)           | `kube-resource-sync` | Experimental | Immediate ConfigMap/Secret synchronization via sidecar            |
+| [Volume Resize](#volume-resize-feature)                 | `volume-resize`      | Experimental | Automatic PVC resizing for Thanos component storage expansion     |
 
 ## Enabling Features
 
@@ -33,7 +34,8 @@ Enable features using the `--enable-feature` flag when starting the operator:
 ./thanos-operator \
   --enable-feature service-monitor \
   --enable-feature prometheus-rule \
-  --enable-feature otel-sidecar
+  --enable-feature otel-sidecar \
+  --enable-feature volume-resize
 ```
 
 ## ServiceMonitor Feature
@@ -284,6 +286,73 @@ The operator exposes metrics about enabled feature gates:
 # Check which features are enabled
 thanos_operator_feature_gates_info{feature="service-monitor"} == 1
 ```
+
+## Volume Resize Feature
+
+**Flag**: `volume-resize`
+
+### What It Achieves
+
+Enables automatic PVC (PersistentVolumeClaim) resizing for Thanos component StatefulSets when storage expansion is needed. This feature allows you to resize storage volumes without manual intervention, providing seamless storage scaling for Thanos components.
+
+### How It Works
+
+The volume resize controller watches for StatefulSets managed by the Thanos Operator and automatically resizes associated PVCs when a storage size annotation indicates a larger size is needed. After successful resize, the StatefulSet is orphaned and recreated to pick up the new volume sizes.
+
+### Resize Process
+
+When the feature is enabled, the controller performs the following steps:
+
+1. **StatefulSet Discovery**: Identifies StatefulSets managed by the Thanos Operator
+2. **Annotation Processing**: Reads the `operator.thanos.io/storage-size` annotation from the StatefulSet
+3. **PVC Comparison**: Compares the requested size with current PVC storage size
+4. **Volume Expansion**: If requested size is larger, updates the PVC storage request
+5. **StatefulSet Recreation**: Orphans and deletes the StatefulSet so it can be recreated with new volume sizes
+
+### Supported Components
+
+The volume resize feature works with all Thanos components that use StatefulSets:
+
+- **ThanosStore**: Storage gateway persistent volumes
+- **ThanosCompact**: Compactor working directory and metadata storage
+- **ThanosRuler**: Rule evaluation state and WAL storage
+- **ThanosReceive**: Ingester TSDB storage
+
+### Storage Class Requirements
+
+The underlying StorageClass must support volume expansion:
+
+```yaml
+allowVolumeExpansion: true  # Required in StorageClass
+```
+
+### Monitoring
+
+The controller exposes metrics for monitoring resize operations:
+
+```promql
+# Total resize attempts
+thanos_operator_volume_resize_attempts_total{statefulset="thanos-store"}
+
+# Resize failures  
+thanos_operator_volume_resize_failures_total{statefulset="thanos-store"}
+```
+
+### Limitations
+
+- **Expansion Only**: Volumes can only be expanded, not shrunk
+- **StorageClass Support**: Requires `allowVolumeExpansion: true` in the StorageClass
+- **Downtime**: StatefulSet recreation causes brief downtime during resize
+- **Filesystem Expansion**: Some filesystems may require manual expansion after PVC resize
+
+### Use Cases
+
+- **Growing Data**: Expanding storage as Thanos data retention grows
+- **Performance Scaling**: Increasing volume size for higher IOPS requirements
+- **Capacity Planning**: Proactive storage expansion based on usage forecasts
+- **Emergency Expansion**: Quick storage increases during unexpected data growth
+
+---
 
 ## See Also
 

--- a/helm/chart/templates/rbac/manager-role.yaml
+++ b/helm/chart/templates/rbac/manager-role.yaml
@@ -7,6 +7,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - persistentvolumeclaims
   - secrets
   - serviceaccounts
   - services

--- a/internal/controller/thanoscompact_controller_test.go
+++ b/internal/controller/thanoscompact_controller_test.go
@@ -185,8 +185,9 @@ config:
 					objs = append(objs, &corev1.ServiceAccount{}, &appsv1.StatefulSet{}, &corev1.Service{})
 
 					expectedAnnotations := map[string]string{
-						"compact-meta": "annotation",
-						"compact-spec": "annotation",
+						"compact-meta":                  "annotation",
+						"compact-spec":                  "annotation",
+						manifests.StorageSizeAnnotation: "1Gi",
 					}
 
 					for _, shard := range []string{shardOne, shardTwo} {

--- a/internal/controller/thanosreceive_controller_test.go
+++ b/internal/controller/thanosreceive_controller_test.go
@@ -279,14 +279,16 @@ config:
 					objs = append(objs, &appsv1.StatefulSet{})
 
 					expectedAnnotations := map[string]string{
-						"receive":  "annotation",
-						"ingestor": "annotation",
-						"conflict": "ingestor-override",
+						"receive":                       "annotation",
+						"ingestor":                      "annotation",
+						"conflict":                      "ingestor-override",
+						manifests.StorageSizeAnnotation: "100Mi",
 					}
 
 					if !utils.VerifyAnnotations(k8sClient, objs, ReceiveIngesterNameFromParent(resourceName, hashringName), ns, expectedAnnotations) {
 						return fmt.Errorf("expected annotation %q not found", expectedAnnotations)
 					}
+
 					return nil
 				}, time.Minute, time.Second*10).Should(Succeed())
 			})

--- a/internal/controller/thanosruler_controller_test.go
+++ b/internal/controller/thanosruler_controller_test.go
@@ -192,8 +192,9 @@ config:
 					objs = append(objs, &corev1.ServiceAccount{}, &appsv1.StatefulSet{}, &corev1.Service{})
 
 					expectedAnnotations := map[string]string{
-						"ruler-meta": "annotation",
-						"ruler-spec": "annotation",
+						"ruler-meta":                    "annotation",
+						"ruler-spec":                    "annotation",
+						manifests.StorageSizeAnnotation: "1Gi",
 					}
 
 					if !utils.VerifyAnnotations(k8sClient, objs, RulerNameFromParent(resourceName), ns, expectedAnnotations) {

--- a/internal/controller/thanosstore_controller_test.go
+++ b/internal/controller/thanosstore_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	monitoringthanosiov1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
+	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -155,8 +156,9 @@ config:
 					objs = append(objs, &corev1.ServiceAccount{}, &corev1.Service{}, &appsv1.StatefulSet{})
 
 					expectedAnnotations := map[string]string{
-						"store-meta": "annotation",
-						"store-spec": "annotation",
+						"store-meta":                    "annotation",
+						"store-spec":                    "annotation",
+						manifests.StorageSizeAnnotation: "1Gi",
 					}
 
 					for _, shard := range []string{firstShard, secondShard, thirdShard} {

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -131,6 +131,7 @@ func QueryFrontendNameFromParent(resourceName string) string {
 
 func rulerV1Alpha1ToOptions(in rulerV1Alpha1TransformInput) manifestruler.Options {
 	opts := commonToOpts(&in.CRD, in.CRD.Spec.Replicas, in.CRD.Spec.CommonFields, &in.CRD.Spec.StatefulSetFields, in.FeatureGate, in.CRD.Spec.Additional)
+	addStorageSizeAnnotation(&opts, in.CRD.Spec.StorageConfiguration.Size)
 	rulerOpts := manifestruler.Options{
 		Options:         opts,
 		AlertmanagerURL: in.CRD.Spec.AlertmanagerURL,
@@ -179,6 +180,8 @@ func receiverV1Alpha1ToIngesterOptions(in receiverV1Alpha1ToIngesterTransformInp
 	}
 
 	opts := commonToOpts(&in.CRD, in.Spec.Replicas, common, &in.CRD.Spec.StatefulSetFields, in.FeatureGate, additional)
+	addStorageSizeAnnotation(&opts, in.Spec.StorageConfiguration.Size)
+
 	ingestOpts := manifestreceive.IngesterOptions{
 		Options:        opts,
 		ObjStoreSecret: secret,
@@ -266,6 +269,8 @@ func ReceiveRouterNameFromParent(resourceName string) string {
 
 func storeV1Alpha1ToOptions(in storeV1Alpha1TransformInput) manifestsstore.Options {
 	opts := commonToOpts(&in.CRD, in.CRD.Spec.Replicas, in.CRD.Spec.CommonFields, &in.CRD.Spec.StatefulSetFields, in.FeatureGate, in.CRD.Spec.Additional)
+	addStorageSizeAnnotation(&opts, in.CRD.Spec.StorageConfiguration.Size)
+
 	var indexHeaderOpts *manifestsstore.IndexHeaderOptions
 	if in.CRD.Spec.IndexHeaderConfig != nil {
 		indexHeaderOpts = &manifestsstore.IndexHeaderOptions{
@@ -314,6 +319,7 @@ func compactV1Alpha1ToOptions(in compactV1Alpha1TransformInput) manifestscompact
 	opts := commonToOpts(&in.CRD, 1, in.CRD.Spec.CommonFields, &in.CRD.Spec.StatefulSetFields, in.FeatureGate, in.CRD.Spec.Additional)
 	// we always set nil for compactor since it should run as single pod
 	opts.PodDisruptionConfig = nil
+	addStorageSizeAnnotation(&opts, in.CRD.Spec.StorageConfiguration.Size)
 
 	downsamplingConfig := func() *manifestscompact.DownsamplingOptions {
 		if in.CRD.Spec.DownsamplingConfig == nil {
@@ -556,4 +562,13 @@ func toManifestCacheConfig(config *v1alpha1.CacheConfig) manifests.CacheConfig {
 		InMemoryCacheConfig: toInMemoryCacheConfig,
 		FromSecret:          nil,
 	}
+}
+
+// addStorageSizeAnnotation adds a storage size annotation to the provided options based on the storage configuration
+func addStorageSizeAnnotation(opts *manifests.Options, storageSize v1alpha1.StorageSize) {
+	if opts.Annotations == nil {
+		opts.Annotations = make(map[string]string)
+	}
+	quantity := storageSize.ToResourceQuantity()
+	opts.Annotations[manifests.StorageSizeAnnotation] = quantity.String()
 }

--- a/internal/controller/volume_resize_controller.go
+++ b/internal/controller/volume_resize_controller.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/events"
 
@@ -131,57 +132,65 @@ func (r *VolumeResizeReconciler) processPVCs(ctx context.Context, sts *appsv1.St
 	r.logger.Info("Found PersistentVolumeClaims for StatefulSet", "statefulset", sts.GetName(), "count", len(pvcList.Items))
 
 	var errCount int
+	var needsRecreation bool
 	for _, pvc := range pvcList.Items {
-		err = r.processPVC(ctx, &pvc, sts)
+		ok, err := r.processPVC(ctx, &pvc, sts)
 		if err != nil {
 			errCount++
 			r.logger.Error(err, "failed to process PersistentVolumeClaim", "pvc", pvc.GetName(), "statefulset", sts.GetName())
 			continue
+		}
+		if !needsRecreation && ok {
+			needsRecreation = true
 		}
 	}
 
 	if errCount > 0 {
 		return fmt.Errorf("encountered errors processing %d PVC(s) for StatefulSet %s", errCount, sts.GetName())
 	}
+
+	if needsRecreation {
+		err = r.orphanAndDeleteStatefulSet(ctx, sts)
+		if err != nil {
+			return fmt.Errorf("failed to orphan and delete StatefulSet: %w", err)
+		}
+	}
+
 	return nil
 }
 
 // processPVC handles volume resize operations for a single PVC
-func (r *VolumeResizeReconciler) processPVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, sts *appsv1.StatefulSet) error {
+func (r *VolumeResizeReconciler) processPVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, sts *appsv1.StatefulSet) (bool, error) {
 	r.logger.Info("Processing PVC", "pvc", pvc.GetName(), "namespace", pvc.GetNamespace())
 
 	requestedSizeStr, exists := sts.GetAnnotations()[manifests.StorageSizeAnnotation]
 	if !exists {
 		r.logger.Info("StatefulSet does not have storage size annotation, skipping", "statefulset", sts.GetName())
-		return nil
+		return false, nil
 	}
 
 	requestedSize, err := parseStorageSize(requestedSizeStr)
 	if err != nil {
-		r.metrics.ResizeFailureTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
-		return fmt.Errorf("failed to parse requested storage size %s for PVC %s: %w", requestedSizeStr, pvc.GetName(), err)
+		return false, fmt.Errorf("failed to parse requested storage size %s for PVC %s: %w", requestedSizeStr, pvc.GetName(), err)
 	}
 
 	currentSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 
 	if requestedSize.Cmp(currentSize) < 1 {
-		return nil
+		return false, nil
 	}
 
+	r.metrics.ResizeAttemptsTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
 	r.logger.Info("volume expansion required",
 		"PersistentVolumeClaim", pvc.GetName(), "currentSize", currentSize.String(), "requestedSize", requestedSize.String())
 
 	err = r.resizePVC(ctx, pvc, requestedSize)
 	if err != nil {
-		r.metrics.ResizeFailureTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
-		return fmt.Errorf("failed to resize PVC %s: %w", pvc.GetName(), err)
+		r.metrics.ResizeFailuresTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
+		return false, fmt.Errorf("failed to resize PVC %s: %w", pvc.GetName(), err)
 	}
 
-	r.metrics.ResizeSuccessTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
-	r.recorder.Eventf(pvc, nil, corev1.EventTypeNormal, "VolumeResized", "VolumeResize",
-		"PVC resized from %s to %s", currentSize.String(), requestedSize.String())
-
-	return nil
+	return true, nil
 }
 
 // resizePVC performs the actual PVC resize operation
@@ -204,6 +213,24 @@ func parseStorageSize(sizeStr string) (resource.Quantity, error) {
 		return resource.Quantity{}, fmt.Errorf("invalid storage size format: %w", err)
 	}
 	return quantity, nil
+}
+
+// orphanAndDeleteStatefulSet orphans the StatefulSet's managed resources and deletes the StatefulSet
+// This allows the operator to recreate it with the new storage configuration
+func (r *VolumeResizeReconciler) orphanAndDeleteStatefulSet(ctx context.Context, sts *appsv1.StatefulSet) error {
+	r.logger.Info("Orphaning and deleting StatefulSet for recreation", "statefulset", sts.GetName())
+
+	err := r.Delete(ctx, sts, client.PropagationPolicy(metav1.DeletePropagationOrphan))
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Info("StatefulSet already deleted", "statefulset", sts.GetName())
+			return nil
+		}
+		return fmt.Errorf("failed to delete StatefulSet: %w", err)
+	}
+
+	r.logger.Info("Successfully orphaned and deleted StatefulSet", "statefulset", sts.GetName())
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -234,8 +261,6 @@ func (r *VolumeResizeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 
 	if err != nil {
-		r.recorder.Eventf(&appsv1.StatefulSet{}, nil, corev1.EventTypeWarning, "SetupFailed", "Setup",
-			"Failed to set up volume resize controller: %v", err)
 		return fmt.Errorf("failed to set up volume resize controller: %w", err)
 	}
 

--- a/internal/controller/volume_resize_controller.go
+++ b/internal/controller/volume_resize_controller.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// VolumeResizeReconciler reconciles volume resize operations for StatefulSets created by thanos operator
+type VolumeResizeReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	logger   logr.Logger
+	recorder events.EventRecorder
+}
+
+// NewVolumeResizeReconciler returns a reconciler for volume resize operations.
+func NewVolumeResizeReconciler(conf Config, client client.Client, scheme *runtime.Scheme) *VolumeResizeReconciler {
+	return &VolumeResizeReconciler{
+		Client:   client,
+		Scheme:   scheme,
+		logger:   conf.InstrumentationConfig.Logger.WithName("volume-resize"),
+		recorder: conf.InstrumentationConfig.EventRecorder,
+	}
+}
+
+//+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile handles volume resize operations for StatefulSets managed by thanos operator
+func (r *VolumeResizeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	sts := &appsv1.StatefulSet{}
+	err := r.Get(ctx, req.NamespacedName, sts)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.logger.Info("StatefulSet not found, ignoring since object may be deleted", "statefulset", req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+		r.logger.Error(err, "failed to get StatefulSet", "statefulset", req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+
+	if !r.isThanosOperatorStatefulSet(sts) {
+		r.logger.V(1).Info("StatefulSet not managed by thanos operator, skipping", "statefulset", req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	r.logger.Info("Processing StatefulSet for volume resize operations", "statefulset", req.NamespacedName)
+
+	err = r.processPVCs(ctx, sts)
+	if err != nil {
+		r.logger.Error(err, "failed to process PVCs for StatefulSet", "statefulset", req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+
+	r.recorder.Eventf(sts, nil, corev1.EventTypeNormal, "VolumeResizeProcessed", "Reconcile",
+		"Successfully processed volume resize for StatefulSet")
+
+	return ctrl.Result{}, nil
+}
+
+// isThanosOperatorStatefulSet checks if a StatefulSet is managed by thanos operator
+func (r *VolumeResizeReconciler) isThanosOperatorStatefulSet(sts *appsv1.StatefulSet) bool {
+	labels := sts.GetLabels()
+	if labels == nil {
+		return false
+	}
+
+	// Check for thanos operator managed-by label
+	managedBy, exists := labels[manifests.ManagedByLabel]
+	if !exists || managedBy != manifests.DefaultManagedByLabel {
+		return false
+	}
+
+	// Check for part-of label to ensure it's a thanos component
+	partOf, exists := labels[manifests.PartOfLabel]
+	if !exists || partOf != manifests.DefaultPartOfLabel {
+		return false
+	}
+
+	return true
+}
+
+// processPVCs handles the volume resize logic for PVCs associated with the StatefulSet
+func (r *VolumeResizeReconciler) processPVCs(ctx context.Context, sts *appsv1.StatefulSet) error {
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	// Create a selector to find PVCs that belong to this StatefulSet
+	labelSelector := client.MatchingLabels{
+		"app.kubernetes.io/instance": sts.GetLabels()["app.kubernetes.io/instance"],
+	}
+
+	err := r.List(ctx, pvcList, client.InNamespace(sts.GetNamespace()), labelSelector)
+	if err != nil {
+		return fmt.Errorf("failed to list PVCs for StatefulSet %s: %w", sts.GetName(), err)
+	}
+
+	r.logger.Info("Found PVCs for StatefulSet", "statefulset", sts.GetName(), "pvcCount", len(pvcList.Items))
+
+	// Process each PVC
+	for _, pvc := range pvcList.Items {
+		err = r.processPVC(ctx, &pvc, sts)
+		if err != nil {
+			r.logger.Error(err, "failed to process PVC", "pvc", pvc.GetName(), "statefulset", sts.GetName())
+			// Continue processing other PVCs even if one fails
+			continue
+		}
+	}
+
+	return nil
+}
+
+// processPVC handles volume resize operations for a single PVC
+func (r *VolumeResizeReconciler) processPVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, sts *appsv1.StatefulSet) error {
+	r.logger.Info("Processing PVC", "pvc", pvc.GetName(), "namespace", pvc.GetNamespace())
+
+	requestedSizeStr, exists := sts.GetAnnotations()[manifests.StorageSizeAnnotation]
+	if !exists {
+		r.logger.V(1).Info("StatefulSet does not have storage size annotation, skipping", "statefulset", sts.GetName())
+		return nil
+	}
+
+	requestedSize, err := parseStorageSize(requestedSizeStr)
+	if err != nil {
+		return fmt.Errorf("failed to parse requested storage size %s for PVC %s: %w", requestedSizeStr, pvc.GetName(), err)
+	}
+
+	currentSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+
+	if requestedSize.Cmp(currentSize) > 0 {
+		r.logger.Info("PVC needs to be resized",
+			"pvc", pvc.GetName(),
+			"currentSize", currentSize.String(),
+			"requestedSize", requestedSize.String())
+
+		err = r.resizePVC(ctx, pvc, requestedSize)
+		if err != nil {
+			return fmt.Errorf("failed to resize PVC %s: %w", pvc.GetName(), err)
+		}
+
+		r.recorder.Eventf(pvc, nil, corev1.EventTypeNormal, "VolumeResized", "VolumeResize",
+			"PVC resized from %s to %s", currentSize.String(), requestedSize.String())
+	} else {
+		r.logger.V(1).Info("PVC does not need resizing", "pvc", pvc.GetName())
+	}
+
+	return nil
+}
+
+// resizePVC performs the actual PVC resize operation
+func (r *VolumeResizeReconciler) resizePVC(ctx context.Context, pvc *corev1.PersistentVolumeClaim, newSize resource.Quantity) error {
+	patch := pvc.DeepCopy()
+	patch.Spec.Resources.Requests[corev1.ResourceStorage] = newSize
+	err := r.Patch(ctx, patch, client.MergeFrom(pvc))
+	if err != nil {
+		return fmt.Errorf("failed to patch PVC: %w", err)
+	}
+
+	r.logger.Info("Successfully resized PVC", "pvc", pvc.GetName(), "newSize", newSize.String())
+	return nil
+}
+
+// parseStorageSize parses a storage size string into a resource.Quantity
+func parseStorageSize(sizeStr string) (resource.Quantity, error) {
+	quantity, err := resource.ParseQuantity(sizeStr)
+	if err != nil {
+		return resource.Quantity{}, fmt.Errorf("invalid storage size format: %w", err)
+	}
+	return quantity, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VolumeResizeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Create a predicate to only watch StatefulSets managed by thanos operator
+	thanosOperatorPredicate := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		labels := object.GetLabels()
+		if labels == nil {
+			return false
+		}
+
+		managedBy, exists := labels[manifests.ManagedByLabel]
+		if !exists || managedBy != manifests.DefaultManagedByLabel {
+			return false
+		}
+
+		partOf, exists := labels[manifests.PartOfLabel]
+		if !exists || partOf != manifests.DefaultPartOfLabel {
+			return false
+		}
+
+		return true
+	})
+
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&appsv1.StatefulSet{}).
+		WithEventFilter(thanosOperatorPredicate).
+		Complete(r)
+
+	if err != nil {
+		r.recorder.Eventf(&appsv1.StatefulSet{}, nil, corev1.EventTypeWarning, "SetupFailed", "Setup",
+			"Failed to set up volume resize controller: %v", err)
+		return fmt.Errorf("failed to set up volume resize controller: %w", err)
+	}
+
+	return nil
+}

--- a/internal/controller/volume_resize_controller.go
+++ b/internal/controller/volume_resize_controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+	"github.com/thanos-community/thanos-operator/internal/pkg/metrics"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,6 +44,7 @@ type VolumeResizeReconciler struct {
 
 	logger   logr.Logger
 	recorder events.EventRecorder
+	metrics  metrics.VolumeResizeMetrics
 }
 
 // NewVolumeResizeReconciler returns a reconciler for volume resize operations.
@@ -52,6 +54,7 @@ func NewVolumeResizeReconciler(conf Config, client client.Client, scheme *runtim
 		Scheme:   scheme,
 		logger:   conf.InstrumentationConfig.Logger.WithName("volume-resize"),
 		recorder: conf.InstrumentationConfig.EventRecorder,
+		metrics:  metrics.NewVolumeResizeMetrics(conf.InstrumentationConfig.MetricsRegistry, conf.InstrumentationConfig.CommonMetrics),
 	}
 }
 
@@ -125,18 +128,21 @@ func (r *VolumeResizeReconciler) processPVCs(ctx context.Context, sts *appsv1.St
 		return fmt.Errorf("failed to list PVCs for StatefulSet %s: %w", sts.GetName(), err)
 	}
 
-	r.logger.Info("Found PVCs for StatefulSet", "statefulset", sts.GetName(), "pvcCount", len(pvcList.Items))
+	r.logger.Info("Found PersistentVolumeClaims for StatefulSet", "statefulset", sts.GetName(), "count", len(pvcList.Items))
 
-	// Process each PVC
+	var errCount int
 	for _, pvc := range pvcList.Items {
 		err = r.processPVC(ctx, &pvc, sts)
 		if err != nil {
-			r.logger.Error(err, "failed to process PVC", "pvc", pvc.GetName(), "statefulset", sts.GetName())
-			// Continue processing other PVCs even if one fails
+			errCount++
+			r.logger.Error(err, "failed to process PersistentVolumeClaim", "pvc", pvc.GetName(), "statefulset", sts.GetName())
 			continue
 		}
 	}
 
+	if errCount > 0 {
+		return fmt.Errorf("encountered errors processing %d PVC(s) for StatefulSet %s", errCount, sts.GetName())
+	}
 	return nil
 }
 
@@ -146,33 +152,34 @@ func (r *VolumeResizeReconciler) processPVC(ctx context.Context, pvc *corev1.Per
 
 	requestedSizeStr, exists := sts.GetAnnotations()[manifests.StorageSizeAnnotation]
 	if !exists {
-		r.logger.V(1).Info("StatefulSet does not have storage size annotation, skipping", "statefulset", sts.GetName())
+		r.logger.Info("StatefulSet does not have storage size annotation, skipping", "statefulset", sts.GetName())
 		return nil
 	}
 
 	requestedSize, err := parseStorageSize(requestedSizeStr)
 	if err != nil {
+		r.metrics.ResizeFailureTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
 		return fmt.Errorf("failed to parse requested storage size %s for PVC %s: %w", requestedSizeStr, pvc.GetName(), err)
 	}
 
 	currentSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 
-	if requestedSize.Cmp(currentSize) > 0 {
-		r.logger.Info("PVC needs to be resized",
-			"pvc", pvc.GetName(),
-			"currentSize", currentSize.String(),
-			"requestedSize", requestedSize.String())
-
-		err = r.resizePVC(ctx, pvc, requestedSize)
-		if err != nil {
-			return fmt.Errorf("failed to resize PVC %s: %w", pvc.GetName(), err)
-		}
-
-		r.recorder.Eventf(pvc, nil, corev1.EventTypeNormal, "VolumeResized", "VolumeResize",
-			"PVC resized from %s to %s", currentSize.String(), requestedSize.String())
-	} else {
-		r.logger.V(1).Info("PVC does not need resizing", "pvc", pvc.GetName())
+	if requestedSize.Cmp(currentSize) < 1 {
+		return nil
 	}
+
+	r.logger.Info("volume expansion required",
+		"PersistentVolumeClaim", pvc.GetName(), "currentSize", currentSize.String(), "requestedSize", requestedSize.String())
+
+	err = r.resizePVC(ctx, pvc, requestedSize)
+	if err != nil {
+		r.metrics.ResizeFailureTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
+		return fmt.Errorf("failed to resize PVC %s: %w", pvc.GetName(), err)
+	}
+
+	r.metrics.ResizeSuccessTotal.WithLabelValues(sts.Name, sts.Namespace, pvc.Name).Inc()
+	r.recorder.Eventf(pvc, nil, corev1.EventTypeNormal, "VolumeResized", "VolumeResize",
+		"PVC resized from %s to %s", currentSize.String(), requestedSize.String())
 
 	return nil
 }

--- a/internal/controller/volume_resize_controller_test.go
+++ b/internal/controller/volume_resize_controller_test.go
@@ -21,10 +21,12 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+	"github.com/thanos-community/thanos-operator/internal/pkg/metrics"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -180,11 +182,16 @@ func TestVolumeResizeReconciler_Reconcile(t *testing.T) {
 			clientBuilder := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.objects...)
 			fakeClient := clientBuilder.Build()
 
+			// Create a fake metrics registry for testing
+			reg := prometheus.NewRegistry()
+			commonMetrics := metrics.NewCommonMetrics(reg)
+
 			reconciler := &VolumeResizeReconciler{
 				Client:   fakeClient,
 				Scheme:   scheme,
 				logger:   logr.Discard(),
 				recorder: events.NewFakeRecorder(10),
+				metrics:  metrics.NewVolumeResizeMetrics(reg, commonMetrics),
 			}
 
 			result, err := reconciler.Reconcile(context.Background(), tt.request)

--- a/internal/controller/volume_resize_controller_test.go
+++ b/internal/controller/volume_resize_controller_test.go
@@ -258,4 +258,3 @@ func TestParseStorageSize(t *testing.T) {
 		})
 	}
 }
-

--- a/internal/controller/volume_resize_controller_test.go
+++ b/internal/controller/volume_resize_controller_test.go
@@ -54,7 +54,7 @@ func TestVolumeResizeReconciler_Reconcile(t *testing.T) {
 		validateFunc func(t *testing.T, fakeClient client.Client)
 	}{
 		{
-			name: "should resize PVC when StatefulSet has storage annotation",
+			name: "should resize PVC and orphan StatefulSet when storage annotation requires expansion",
 			objects: []runtime.Object{
 				&appsv1.StatefulSet{
 					ObjectMeta: metav1.ObjectMeta{
@@ -112,6 +112,16 @@ func TestVolumeResizeReconciler_Reconcile(t *testing.T) {
 				actualSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
 				assert.True(t, expectedSize.Equal(actualSize),
 					"Expected PVC size %s, got %s", expectedSize.String(), actualSize.String())
+
+				// After reconciliation, the StatefulSet should be deleted (orphaned)
+				// since needsRecreation was triggered by the PVC resize
+				sts := &appsv1.StatefulSet{}
+				err = fakeClient.Get(context.Background(), types.NamespacedName{
+					Name:      "test-store",
+					Namespace: "test-ns",
+				}, sts)
+				assert.Error(t, err, "StatefulSet should be deleted after PVC resize")
+				assert.Contains(t, err.Error(), "not found", "Expected 'not found' error when StatefulSet is deleted")
 			},
 		},
 		{
@@ -248,3 +258,4 @@ func TestParseStorageSize(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/controller/volume_resize_controller_test.go
+++ b/internal/controller/volume_resize_controller_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestVolumeResizeReconciler_Reconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	tests := []struct {
+		name         string
+		objects      []runtime.Object
+		request      reconcile.Request
+		wantErr      bool
+		wantResult   reconcile.Result
+		validateFunc func(t *testing.T, fakeClient client.Client)
+	}{
+		{
+			name: "should resize PVC when StatefulSet has storage annotation",
+			objects: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-store",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							manifests.ManagedByLabel:     manifests.DefaultManagedByLabel,
+							manifests.PartOfLabel:        manifests.DefaultPartOfLabel,
+							"app.kubernetes.io/instance": "test-instance",
+						},
+						Annotations: map[string]string{
+							manifests.StorageSizeAnnotation: "20Gi",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						ServiceName: "test-store",
+						Replicas:    &[]int32{1}[0],
+					},
+				},
+				&corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "data-test-store-0",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"app.kubernetes.io/instance": "test-instance",
+						},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-store",
+					Namespace: "test-ns",
+				},
+			},
+			wantErr:    false,
+			wantResult: reconcile.Result{},
+			validateFunc: func(t *testing.T, fakeClient client.Client) {
+				// After reconciliation, the PVC should be resized to 20Gi
+				pvc := &corev1.PersistentVolumeClaim{}
+				err := fakeClient.Get(context.Background(), types.NamespacedName{
+					Name:      "data-test-store-0",
+					Namespace: "test-ns",
+				}, pvc)
+				require.NoError(t, err)
+
+				expectedSize := resource.MustParse("20Gi")
+				actualSize := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+				assert.True(t, expectedSize.Equal(actualSize),
+					"Expected PVC size %s, got %s", expectedSize.String(), actualSize.String())
+			},
+		},
+		{
+			name: "should skip StatefulSet without thanos operator labels",
+			objects: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "other-sts",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"app": "other-app",
+						},
+						Annotations: map[string]string{
+							manifests.StorageSizeAnnotation: "20Gi",
+						},
+					},
+				},
+			},
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "other-sts",
+					Namespace: "test-ns",
+				},
+			},
+			wantErr:    false,
+			wantResult: reconcile.Result{},
+		},
+		{
+			name: "should skip StatefulSet without storage annotation",
+			objects: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-store",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							manifests.ManagedByLabel:     manifests.DefaultManagedByLabel,
+							manifests.PartOfLabel:        manifests.DefaultPartOfLabel,
+							"app.kubernetes.io/instance": "test-instance",
+						},
+					},
+				},
+			},
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "test-store",
+					Namespace: "test-ns",
+				},
+			},
+			wantErr:    false,
+			wantResult: reconcile.Result{},
+		},
+		{
+			name:    "should handle StatefulSet not found",
+			objects: []runtime.Object{},
+			request: reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "non-existent",
+					Namespace: "test-ns",
+				},
+			},
+			wantErr:    false,
+			wantResult: reconcile.Result{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientBuilder := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(tt.objects...)
+			fakeClient := clientBuilder.Build()
+
+			reconciler := &VolumeResizeReconciler{
+				Client:   fakeClient,
+				Scheme:   scheme,
+				logger:   logr.Discard(),
+				recorder: events.NewFakeRecorder(10),
+			}
+
+			result, err := reconciler.Reconcile(context.Background(), tt.request)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantResult, result)
+
+			if tt.validateFunc != nil {
+				tt.validateFunc(t, fakeClient)
+			}
+		})
+	}
+}
+
+func TestParseStorageSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		sizeStr string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "valid size with Gi",
+			sizeStr: "10Gi",
+			want:    "10Gi",
+			wantErr: false,
+		},
+		{
+			name:    "valid size with Mi",
+			sizeStr: "1024Mi",
+			want:    "1Gi",
+			wantErr: false,
+		},
+		{
+			name:    "invalid size format",
+			sizeStr: "invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseStorageSize(tt.sizeStr)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}

--- a/internal/pkg/featuregate/features.go
+++ b/internal/pkg/featuregate/features.go
@@ -22,6 +22,9 @@ const (
 	// KubeResourceSync enables the kube-resource-sync sidecar for immediate ConfigMap/Secret synchronization.
 	// See https://github.com/philipgough/kube-resource-sync
 	KubeResourceSync = "kube-resource-sync"
+
+	// VolumeResize enables the volume resize controller for automatic PVC resizing.
+	VolumeResize = "volume-resize"
 )
 
 // AllFeatures returns a slice of all available feature flag names.
@@ -32,6 +35,7 @@ func AllFeatures() []string {
 		PrometheusRule,
 		KubeResourceSync,
 		OtelSidecar,
+		VolumeResize,
 	}
 }
 
@@ -58,6 +62,8 @@ type Config struct {
 	EnableKubeResourceSync bool
 	// KubeResourceSyncImage specifies the image to use for the kube-resource-sync sidecar.
 	KubeResourceSyncImage string
+	// EnableVolumeResize enables the volume resize controller.
+	EnableVolumeResize bool
 }
 
 // ServiceMonitorEnabled returns true if ServiceMonitor management is enabled.
@@ -80,6 +86,11 @@ func (c Config) KubeResourceSyncEnabled() bool {
 	return c.EnableKubeResourceSync
 }
 
+// VolumeResizeEnabled returns true if volume resize controller is enabled.
+func (c Config) VolumeResizeEnabled() bool {
+	return c.EnableVolumeResize
+}
+
 // GetKubeResourceSyncImage returns the image used for the kube-resource-sync sidecar.
 func (c Config) GetKubeResourceSyncImage() string {
 	return c.KubeResourceSyncImage
@@ -92,6 +103,7 @@ func (f *Flag) ToFeatureGate() Config {
 		EnablePrometheusRuleDiscovery: f.EnablesPrometheusRule(),
 		EnableOtelSidecar:             f.EnablesOtelSidecar(),
 		EnableKubeResourceSync:        f.EnablesKubeResourceSync(),
+		EnableVolumeResize:            f.EnablesVolumeResize(),
 	}
 }
 

--- a/internal/pkg/featuregate/features_test.go
+++ b/internal/pkg/featuregate/features_test.go
@@ -14,6 +14,7 @@ func TestAllFeatures(t *testing.T) {
 		PrometheusRule,
 		OtelSidecar,
 		KubeResourceSync,
+		VolumeResize,
 	}
 	got := AllFeatures()
 	slices.Sort(expected)
@@ -41,6 +42,11 @@ func TestIsValidFeature(t *testing.T) {
 		{
 			name:    "valid otel-sidecar",
 			feature: OtelSidecar,
+			want:    true,
+		},
+		{
+			name:    "valid volume-resize",
+			feature: VolumeResize,
 			want:    true,
 		},
 		{
@@ -91,6 +97,33 @@ func TestConfig_OtelSidecarEnabled(t *testing.T) {
 	}
 }
 
+func TestConfig_VolumeResizeEnabled(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		want   bool
+	}{
+		{
+			name:   "volume resize enabled",
+			config: Config{EnableVolumeResize: true},
+			want:   true,
+		},
+		{
+			name:   "volume resize disabled",
+			config: Config{EnableVolumeResize: false},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.config.VolumeResizeEnabled(); got != tt.want {
+				t.Errorf("Config.VolumeResizeEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFlag_ToFeatureGate(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -104,15 +137,17 @@ func TestFlag_ToFeatureGate(t *testing.T) {
 				EnableServiceMonitor:          false,
 				EnablePrometheusRuleDiscovery: false,
 				EnableOtelSidecar:             false,
+				EnableVolumeResize:            false,
 			},
 		},
 		{
 			name:     "all features enabled",
-			features: []string{ServiceMonitor, PrometheusRule, OtelSidecar},
+			features: []string{ServiceMonitor, PrometheusRule, OtelSidecar, VolumeResize},
 			want: Config{
 				EnableServiceMonitor:          true,
 				EnablePrometheusRuleDiscovery: true,
 				EnableOtelSidecar:             true,
+				EnableVolumeResize:            true,
 			},
 		},
 	}

--- a/internal/pkg/featuregate/flag.go
+++ b/internal/pkg/featuregate/flag.go
@@ -52,3 +52,8 @@ func (f *Flag) EnablesOtelSidecar() bool {
 func (f *Flag) EnablesKubeResourceSync() bool {
 	return f.Contains(KubeResourceSync)
 }
+
+// EnablesVolumeResize returns true if volume resize features should be enabled.
+func (f *Flag) EnablesVolumeResize() bool {
+	return f.Contains(VolumeResize)
+}

--- a/internal/pkg/featuregate/flag_test.go
+++ b/internal/pkg/featuregate/flag_test.go
@@ -27,6 +27,11 @@ func TestFlag_Set(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "valid volume-resize",
+			feature: VolumeResize,
+			wantErr: false,
+		},
+		{
 			name:        "invalid feature",
 			feature:     "invalid-feature",
 			wantErr:     true,
@@ -196,6 +201,48 @@ func TestFlag_EnablesOtelSidecar(t *testing.T) {
 
 			if got := f.EnablesOtelSidecar(); got != tt.want {
 				t.Errorf("Flag.EnablesOtelSidecar() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlag_EnablesVolumeResize(t *testing.T) {
+	tests := []struct {
+		name     string
+		features []string
+		want     bool
+	}{
+		{
+			name:     "no features",
+			features: []string{},
+			want:     false,
+		},
+		{
+			name:     "volume-resize enables volume resize",
+			features: []string{VolumeResize},
+			want:     true,
+		},
+		{
+			name:     "service-monitor does not enable volume resize",
+			features: []string{ServiceMonitor},
+			want:     false,
+		},
+		{
+			name:     "multiple features including volume-resize",
+			features: []string{ServiceMonitor, VolumeResize},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &Flag{}
+			for _, feature := range tt.features {
+				_ = f.Set(feature)
+			}
+
+			if got := f.EnablesVolumeResize(); got != tt.want {
+				t.Errorf("Flag.EnablesVolumeResize() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/pkg/manifests/labels.go
+++ b/internal/pkg/manifests/labels.go
@@ -54,6 +54,9 @@ const (
 
 	HashringLabel = "operator.thanos.io/hashring"
 	ShardLabel    = "operator.thanos.io/shard"
+
+	// StorageSizeAnnotation is the annotation used to identify the requested storage size.
+	StorageSizeAnnotation = "operator.thanos.io/storage-size"
 )
 
 // MergeMaps merges the provided labels with the default labels for a component.

--- a/internal/pkg/metrics/controller_metrics.go
+++ b/internal/pkg/metrics/controller_metrics.go
@@ -55,8 +55,8 @@ type ThanosCompactMetrics struct {
 
 type VolumeResizeMetrics struct {
 	*CommonMetrics
-	ResizeSuccessTotal *prometheus.CounterVec
-	ResizeFailureTotal *prometheus.CounterVec
+	ResizeAttemptsTotal *prometheus.CounterVec
+	ResizeFailuresTotal *prometheus.CounterVec
 }
 
 var (
@@ -197,12 +197,12 @@ func NewThanosCompactMetrics(reg prometheus.Registerer, commonMetrics *CommonMet
 func NewVolumeResizeMetrics(reg prometheus.Registerer, commonMetrics *CommonMetrics) VolumeResizeMetrics {
 	return VolumeResizeMetrics{
 		CommonMetrics: commonMetrics,
-		ResizeSuccessTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "thanos_operator_volume_resize_success_total",
-			Help: "Total number of successful PVC resize operations",
+		ResizeAttemptsTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_operator_volume_resize_attempts_total",
+			Help: "Total number of PVC resize attempts",
 		}, []string{"statefulset", "namespace", "pvc"}),
-		ResizeFailureTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "thanos_operator_volume_resize_failure_total",
+		ResizeFailuresTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_operator_volume_resize_failures_total",
 			Help: "Total number of failed PVC resize operations",
 		}, []string{"statefulset", "namespace", "pvc"}),
 	}

--- a/internal/pkg/metrics/controller_metrics.go
+++ b/internal/pkg/metrics/controller_metrics.go
@@ -53,6 +53,12 @@ type ThanosCompactMetrics struct {
 	ShardCreationUpdateFailures *prometheus.CounterVec
 }
 
+type VolumeResizeMetrics struct {
+	*CommonMetrics
+	ResizeSuccessTotal *prometheus.CounterVec
+	ResizeFailureTotal *prometheus.CounterVec
+}
+
 var (
 	commonMetricsInstance *CommonMetrics
 	commonMetricsOnce     sync.Once
@@ -185,5 +191,19 @@ func NewThanosCompactMetrics(reg prometheus.Registerer, commonMetrics *CommonMet
 			Name: "thanos_operator_compact_shards_creation_update_failures_total",
 			Help: "Number of shard creation/update failures for ThanosCompact resources",
 		}, []string{"resource", "namespace"}),
+	}
+}
+
+func NewVolumeResizeMetrics(reg prometheus.Registerer, commonMetrics *CommonMetrics) VolumeResizeMetrics {
+	return VolumeResizeMetrics{
+		CommonMetrics: commonMetrics,
+		ResizeSuccessTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_operator_volume_resize_success_total",
+			Help: "Total number of successful PVC resize operations",
+		}, []string{"statefulset", "namespace", "pvc"}),
+		ResizeFailureTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "thanos_operator_volume_resize_failure_total",
+			Help: "Total number of failed PVC resize operations",
+		}, []string{"statefulset", "namespace", "pvc"}),
 	}
 }

--- a/website/content/docs/guides/gated-features.md
+++ b/website/content/docs/guides/gated-features.md
@@ -342,15 +342,6 @@ thanos_operator_volume_resize_failures_total{statefulset="thanos-store"}
 
 - **Expansion Only**: Volumes can only be expanded, not shrunk
 - **StorageClass Support**: Requires `allowVolumeExpansion: true` in the StorageClass
-- **Downtime**: StatefulSet recreation causes brief downtime during resize
-- **Filesystem Expansion**: Some filesystems may require manual expansion after PVC resize
-
-### Use Cases
-
-- **Growing Data**: Expanding storage as Thanos data retention grows
-- **Performance Scaling**: Increasing volume size for higher IOPS requirements
-- **Capacity Planning**: Proactive storage expansion based on usage forecasts
-- **Emergency Expansion**: Quick storage increases during unexpected data growth
 
 ---
 

--- a/website/content/docs/guides/gated-features.md
+++ b/website/content/docs/guides/gated-features.md
@@ -18,6 +18,7 @@ Feature gates allow you to:
 | [PrometheusRule](#prometheusrule-feature)               | `prometheus-rule`    | Experimental | Automatic discovery and mounting of PrometheusRule objects        |
 | [OpenTelemetry Sidecar](#opentelemetry-sidecar-feature) | `otel-sidecar`       | Experimental | OpenTelemetry collector sidecar injection for distributed tracing |
 | [KubeResourceSync](#kuberesourcesync-feature)           | `kube-resource-sync` | Experimental | Immediate ConfigMap/Secret synchronization via sidecar            |
+| [Volume Resize](#volume-resize-feature)                 | `volume-resize`      | Experimental | Automatic PVC resizing for Thanos component storage expansion     |
 
 ## Enabling Features
 
@@ -33,7 +34,8 @@ Enable features using the `--enable-feature` flag when starting the operator:
 ./thanos-operator \
   --enable-feature service-monitor \
   --enable-feature prometheus-rule \
-  --enable-feature otel-sidecar
+  --enable-feature otel-sidecar \
+  --enable-feature volume-resize
 ```
 
 ## ServiceMonitor Feature
@@ -284,6 +286,73 @@ The operator exposes metrics about enabled feature gates:
 # Check which features are enabled
 thanos_operator_feature_gates_info{feature="service-monitor"} == 1
 ```
+
+## Volume Resize Feature
+
+**Flag**: `volume-resize`
+
+### What It Achieves
+
+Enables automatic PVC (PersistentVolumeClaim) resizing for Thanos component StatefulSets when storage expansion is needed. This feature allows you to resize storage volumes without manual intervention, providing seamless storage scaling for Thanos components.
+
+### How It Works
+
+The volume resize controller watches for StatefulSets managed by the Thanos Operator and automatically resizes associated PVCs when a storage size annotation indicates a larger size is needed. After successful resize, the StatefulSet is orphaned and recreated to pick up the new volume sizes.
+
+### Resize Process
+
+When the feature is enabled, the controller performs the following steps:
+
+1. **StatefulSet Discovery**: Identifies StatefulSets managed by the Thanos Operator
+2. **Annotation Processing**: Reads the `operator.thanos.io/storage-size` annotation from the StatefulSet
+3. **PVC Comparison**: Compares the requested size with current PVC storage size
+4. **Volume Expansion**: If requested size is larger, updates the PVC storage request
+5. **StatefulSet Recreation**: Orphans and deletes the StatefulSet so it can be recreated with new volume sizes
+
+### Supported Components
+
+The volume resize feature works with all Thanos components that use StatefulSets:
+
+- **ThanosStore**: Storage gateway persistent volumes
+- **ThanosCompact**: Compactor working directory and metadata storage
+- **ThanosRuler**: Rule evaluation state and WAL storage
+- **ThanosReceive**: Ingester TSDB storage
+
+### Storage Class Requirements
+
+The underlying StorageClass must support volume expansion:
+
+```yaml
+allowVolumeExpansion: true  # Required in StorageClass
+```
+
+### Monitoring
+
+The controller exposes metrics for monitoring resize operations:
+
+```promql
+# Total resize attempts
+thanos_operator_volume_resize_attempts_total{statefulset="thanos-store"}
+
+# Resize failures  
+thanos_operator_volume_resize_failures_total{statefulset="thanos-store"}
+```
+
+### Limitations
+
+- **Expansion Only**: Volumes can only be expanded, not shrunk
+- **StorageClass Support**: Requires `allowVolumeExpansion: true` in the StorageClass
+- **Downtime**: StatefulSet recreation causes brief downtime during resize
+- **Filesystem Expansion**: Some filesystems may require manual expansion after PVC resize
+
+### Use Cases
+
+- **Growing Data**: Expanding storage as Thanos data retention grows
+- **Performance Scaling**: Increasing volume size for higher IOPS requirements
+- **Capacity Planning**: Proactive storage expansion based on usage forecasts
+- **Emergency Expansion**: Quick storage increases during unexpected data growth
+
+---
 
 ## See Also
 


### PR DESCRIPTION
Fixes #492 
Supersedes #497 

# Add volume resize controller

## What we did

Added a new controller that automatically resizes PVCs for Thanos StatefulSets when storage requirements increase. This is behind a feature gate! 

## Why

Users need to resize storage for Thanos components (ruler, store, compact, receive) without manual PVC management or StatefulSet recreation.

## How it works

Controller watches StatefulSets with thanos-operator labels:
- Reads storage size from `operator.thanos.io/storage-size` annotation
- Resizes PVCs when annotation shows size increase
- Orphans and recreates StatefulSet when VolumeClaimTemplate needs updating