### PR TITLE
querier: Add store limits flags

### DIFF
--- a/api/v1alpha1/thanosquery_types.go
+++ b/api/v1alpha1/thanosquery_types.go
@@ -54,6 +54,9 @@ type ThanosQuerySpec struct {
 	// If you specify this, the operator will create a Query Frontend in front of your query deployment.
 	// +kubebuilder:validation:Optional
 	QueryFrontend *QueryFrontendSpec `json:"queryFrontend,omitempty"`
+	// StoreLimitsOptions allows configuration of the store API limits.
+	// +kubebuilder:validation:Optional
+	StoreLimitsOptions *StoreLimitsOptions `json:"storeLimitsOptions,omitempty"`
 	// When a resource is paused, no actions except for deletion
 	// will be performed on the underlying objects.
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1172,6 +1172,11 @@ func (in *ThanosQuerySpec) DeepCopyInto(out *ThanosQuerySpec) {
 		*out = new(QueryFrontendSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.StoreLimitsOptions != nil {
+		in, out := &in.StoreLimitsOptions, &out.StoreLimitsOptions
+		*out = new(StoreLimitsOptions)
+		**out = **in
+	}
 	if in.Paused != nil {
 		in, out := &in.Paused, &out.Paused
 		*out = new(bool)

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -16447,6 +16447,25 @@ spec:
                         type: string
                     type: object
                 type: object
+              storeLimitsOptions:
+                description: StoreLimitsOptions allows configuration of the store
+                  API limits.
+                properties:
+                  storeLimitsRequestSamples:
+                    default: 0
+                    description: |-
+                      StoreLimitsRequestSamples is the maximum samples allowed for a single StoreAPI Series request.
+                      0 means no limit.
+                    format: int64
+                    type: integer
+                  storeLimitsRequestSeries:
+                    default: 0
+                    description: |-
+                      StoreLimitsRequestSeries is the maximum series allowed for a single StoreAPI Series request.
+                      0 means no limit.
+                    format: int64
+                    type: integer
+                type: object
               telemetryQuantiles:
                 description: TelemetryQuantiles is the configuration for the request
                   telemetry quantiles.

--- a/config/crd/bases/monitoring.thanos.io_thanosqueries.yaml
+++ b/config/crd/bases/monitoring.thanos.io_thanosqueries.yaml
@@ -10665,6 +10665,25 @@ spec:
                         type: string
                     type: object
                 type: object
+              storeLimitsOptions:
+                description: StoreLimitsOptions allows configuration of the store
+                  API limits.
+                properties:
+                  storeLimitsRequestSamples:
+                    default: 0
+                    description: |-
+                      StoreLimitsRequestSamples is the maximum samples allowed for a single StoreAPI Series request.
+                      0 means no limit.
+                    format: int64
+                    type: integer
+                  storeLimitsRequestSeries:
+                    default: 0
+                    description: |-
+                      StoreLimitsRequestSeries is the maximum series allowed for a single StoreAPI Series request.
+                      0 means no limit.
+                    format: int64
+                    type: integer
+                type: object
               telemetryQuantiles:
                 description: TelemetryQuantiles is the configuration for the request
                   telemetry quantiles.

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -830,6 +830,7 @@ StoreLimitsOptions is the configuration for the store API limits options.
 
 _Appears in:_
 - [IngesterHashringSpec](#ingesterhashringspec)
+- [ThanosQuerySpec](#thanosqueryspec)
 - [ThanosStoreSpec](#thanosstorespec)
 
 | Field | Description | Default | Validation |
@@ -1088,6 +1089,7 @@ _Appears in:_
 | `webConfig` _[WebConfig](#webconfig)_ | WebConfig is the configuration for the Query UI and API web options. |  | Optional: \{\} <br /> |
 | `grpcProxyStrategy` _string_ | GRPCProxyStrategy is the strategy to use when proxying Series requests to leaf nodes. | eager | Enum: [eager lazy] <br /> |
 | `queryFrontend` _[QueryFrontendSpec](#queryfrontendspec)_ | QueryFrontend is the configuration for the Query Frontend<br />If you specify this, the operator will create a Query Frontend in front of your query deployment. |  | Optional: \{\} <br /> |
+| `storeLimitsOptions` _[StoreLimitsOptions](#storelimitsoptions)_ | StoreLimitsOptions allows configuration of the store API limits. |  | Optional: \{\} <br /> |
 | `paused` _boolean_ | When a resource is paused, no actions except for deletion<br />will be performed on the underlying objects. |  | Optional: \{\} <br /> |
 | `additionalArgs` _string array_ | Additional arguments to pass to the Thanos components.<br />An additional argument will override an existing argument provided by the operator if there is a conflict. |  | Optional: \{\} <br /> |
 | `additionalContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#container-v1-core) array_ | Additional containers to add to the Thanos components. |  | Optional: \{\} <br /> |

--- a/helm/chart/templates/crd/thanosqueries.monitoring.thanos.io.yaml
+++ b/helm/chart/templates/crd/thanosqueries.monitoring.thanos.io.yaml
@@ -10668,6 +10668,25 @@ spec:
                         type: string
                     type: object
                 type: object
+              storeLimitsOptions:
+                description: StoreLimitsOptions allows configuration of the store
+                  API limits.
+                properties:
+                  storeLimitsRequestSamples:
+                    default: 0
+                    description: |-
+                      StoreLimitsRequestSamples is the maximum samples allowed for a single StoreAPI Series request.
+                      0 means no limit.
+                    format: int64
+                    type: integer
+                  storeLimitsRequestSeries:
+                    default: 0
+                    description: |-
+                      StoreLimitsRequestSeries is the maximum series allowed for a single StoreAPI Series request.
+                      0 means no limit.
+                    format: int64
+                    type: integer
+                type: object
               telemetryQuantiles:
                 description: TelemetryQuantiles is the configuration for the request
                   telemetry quantiles.

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -79,7 +79,7 @@ func queryV1Alpha1ToOptions(in queryV1Alpha1TransformInput) manifestquery.Option
 			Series:   in.CRD.Spec.TelemetryQuantiles.Series,
 		}
 	}
-	return manifestquery.Options{
+	qopts := manifestquery.Options{
 		Options:            opts,
 		ReplicaLabels:      in.CRD.Spec.ReplicaLabels,
 		Timeout:            "15m",
@@ -89,6 +89,15 @@ func queryV1Alpha1ToOptions(in queryV1Alpha1TransformInput) manifestquery.Option
 		TelemetryQuantiles: telemetryQuantiles,
 		GRPCProxyStrategy:  in.CRD.Spec.GRPCProxyStrategy,
 	}
+
+	if in.CRD.Spec.StoreLimitsOptions != nil {
+		qopts.StoreLimitsOpts = manifests.StoreLimitsOpts{
+			StoreLimitsRequestSamples: in.CRD.Spec.StoreLimitsOptions.StoreLimitsRequestSamples,
+			StoreLimitsRequestSeries:  in.CRD.Spec.StoreLimitsOptions.StoreLimitsRequestSeries,
+		}
+	}
+
+	return qopts
 }
 
 // QueryNameFromParent returns the name of the Thanos Query component.

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -38,6 +38,7 @@ type Options struct {
 	WebOptions         WebOptions
 	TelemetryQuantiles TelemetryQuantiles
 	GRPCProxyStrategy  string
+	StoreLimitsOpts    manifests.StoreLimitsOpts
 	Endpoints          []Endpoint
 }
 
@@ -274,6 +275,7 @@ func queryArgs(opts Options) []string {
 		fmt.Sprintf("--web.prefix-header=%s", opts.WebOptions.PrefixHeader),
 		fmt.Sprintf("--grpc.proxy-strategy=%s", opts.GRPCProxyStrategy),
 	)
+	args = append(args, opts.StoreLimitsOpts.ToFlags()...)
 
 	for _, duration := range opts.TelemetryQuantiles.Duration {
 		args = append(args, fmt.Sprintf("--query.telemetry.request-duration-seconds-quantiles=%s", duration))

--- a/website/content/docs/api-reference/api.md
+++ b/website/content/docs/api-reference/api.md
@@ -840,6 +840,7 @@ StoreLimitsOptions is the configuration for the store API limits options.
 
 _Appears in:_
 - [IngesterHashringSpec](#ingesterhashringspec)
+- [ThanosQuerySpec](#thanosqueryspec)
 - [ThanosStoreSpec](#thanosstorespec)
 
 | Field | Description | Default | Validation |
@@ -1098,6 +1099,7 @@ _Appears in:_
 | `webConfig` _[WebConfig](#webconfig)_ | WebConfig is the configuration for the Query UI and API web options. |  | Optional: \{\} <br /> |
 | `grpcProxyStrategy` _string_ | GRPCProxyStrategy is the strategy to use when proxying Series requests to leaf nodes. | eager | Enum: [eager lazy] <br /> |
 | `queryFrontend` _[QueryFrontendSpec](#queryfrontendspec)_ | QueryFrontend is the configuration for the Query Frontend<br />If you specify this, the operator will create a Query Frontend in front of your query deployment. |  | Optional: \{\} <br /> |
+| `storeLimitsOptions` _[StoreLimitsOptions](#storelimitsoptions)_ | StoreLimitsOptions allows configuration of the store API limits. |  | Optional: \{\} <br /> |
 | `paused` _boolean_ | When a resource is paused, no actions except for deletion<br />will be performed on the underlying objects. |  | Optional: \{\} <br /> |
 | `additionalArgs` _string array_ | Additional arguments to pass to the Thanos components.<br />An additional argument will override an existing argument provided by the operator if there is a conflict. |  | Optional: \{\} <br /> |
 | `additionalContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#container-v1-core) array_ | Additional containers to add to the Thanos components. |  | Optional: \{\} <br /> |


### PR DESCRIPTION
This commit add the store API limits flags to querier, as it also has a proxy store internally where these limits can be applied.