### PR TITLE
store: Add downloaded bytes limit flag

### DIFF
--- a/api/v1alpha1/thanosstore_types.go
+++ b/api/v1alpha1/thanosstore_types.go
@@ -67,6 +67,11 @@ type ThanosStoreSpec struct {
 	// BlockConfig defines settings for block handling.
 	// +kubebuilder:validation:Optional
 	BlockConfig *BlockConfig `json:"blockConfig,omitempty"`
+	// DownloadedBytesLimit is the maximum amount of downloaded (either fetched or touched) bytes
+	// in a single Series/LabelNames/LabelValues gRPC call. The Series call fails if this limit is exceeded.
+	// +kubebuilder:default=0
+	// +kubebuilder:validation:Optional
+	DownloadedBytesLimit *uint64 `json:"downloadedBytesLimit,omitempty"`
 	// When a resource is paused, no actions except for deletion
 	// will be performed on the underlying objects.
 	// +kubebuilder:validation:Optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1568,6 +1568,11 @@ func (in *ThanosStoreSpec) DeepCopyInto(out *ThanosStoreSpec) {
 		*out = new(BlockConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.DownloadedBytesLimit != nil {
+		in, out := &in.DownloadedBytesLimit, &out.DownloadedBytesLimit
+		*out = new(uint64)
+		**out = **in
+	}
 	if in.Paused != nil {
 		in, out := &in.Paused, &out.Paused
 		*out = new(bool)

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -38551,6 +38551,13 @@ spec:
                 items:
                   type: string
                 type: array
+              downloadedBytesLimit:
+                default: 0
+                description: |-
+                  DownloadedBytesLimit is the maximum amount of downloaded (either fetched or touched) bytes
+                  in a single Series/LabelNames/LabelValues gRPC call. The Series call fails if this limit is exceeded.
+                format: int64
+                type: integer
               ignoreDeletionMarksDelay:
                 default: 24h
                 description: |-

--- a/config/crd/bases/monitoring.thanos.io_thanosstores.yaml
+++ b/config/crd/bases/monitoring.thanos.io_thanosstores.yaml
@@ -4814,6 +4814,13 @@ spec:
                 items:
                   type: string
                 type: array
+              downloadedBytesLimit:
+                default: 0
+                description: |-
+                  DownloadedBytesLimit is the maximum amount of downloaded (either fetched or touched) bytes
+                  in a single Series/LabelNames/LabelValues gRPC call. The Series call fails if this limit is exceeded.
+                format: int64
+                type: integer
               ignoreDeletionMarksDelay:
                 default: 24h
                 description: |-

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -1407,6 +1407,7 @@ _Appears in:_
 | `storeLimitsOptions` _[StoreLimitsOptions](#storelimitsoptions)_ | StoreLimitsOptions allows configuration of the store API limits. |  | Optional: \{\} <br /> |
 | `indexHeaderConfig` _[IndexHeaderConfig](#indexheaderconfig)_ | IndexHeaderConfig allows configuration of the Store Gateway index header. |  | Optional: \{\} <br /> |
 | `blockConfig` _[BlockConfig](#blockconfig)_ | BlockConfig defines settings for block handling. |  | Optional: \{\} <br /> |
+| `downloadedBytesLimit` _integer_ | DownloadedBytesLimit is the maximum amount of downloaded (either fetched or touched) bytes<br />in a single Series/LabelNames/LabelValues gRPC call. The Series call fails if this limit is exceeded. | 0 | Optional: \{\} <br /> |
 | `paused` _boolean_ | When a resource is paused, no actions except for deletion<br />will be performed on the underlying objects. |  | Optional: \{\} <br /> |
 | `additionalArgs` _string array_ | Additional arguments to pass to the Thanos components.<br />An additional argument will override an existing argument provided by the operator if there is a conflict. |  | Optional: \{\} <br /> |
 | `additionalContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#container-v1-core) array_ | Additional containers to add to the Thanos components. |  | Optional: \{\} <br /> |

--- a/helm/chart/templates/crd/thanosstores.monitoring.thanos.io.yaml
+++ b/helm/chart/templates/crd/thanosstores.monitoring.thanos.io.yaml
@@ -4817,6 +4817,13 @@ spec:
                 items:
                   type: string
                 type: array
+              downloadedBytesLimit:
+                default: 0
+                description: |-
+                  DownloadedBytesLimit is the maximum amount of downloaded (either fetched or touched) bytes
+                  in a single Series/LabelNames/LabelValues gRPC call. The Series call fails if this limit is exceeded.
+                format: int64
+                type: integer
               ignoreDeletionMarksDelay:
                 default: 24h
                 description: |-

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -302,6 +302,8 @@ func storeV1Alpha1ToOptions(in storeV1Alpha1TransformInput) manifestsstore.Optio
 		sops.Max = manifests.Duration(manifests.OptionalToString(in.CRD.Spec.TimeRangeConfig.MaxTime))
 	}
 
+	sops.DownloadedBytesLimit = in.CRD.Spec.DownloadedBytesLimit
+
 	return sops
 }
 

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -45,6 +45,7 @@ type Options struct {
 	RelabelConfigs           manifests.RelabelConfigs
 	ShardIndex               *int32
 	StoreLimitsOpts          manifests.StoreLimitsOpts
+	DownloadedBytesLimit     *uint64
 	IndexHeaderOptions       *IndexHeaderOptions
 	BlockConfigOptions       *BlockConfigOptions
 }
@@ -339,6 +340,11 @@ func storeArgsFrom(opts Options) []string {
 	)
 
 	args = append(args, opts.StoreLimitsOpts.ToFlags()...)
+
+	if opts.DownloadedBytesLimit != nil && *opts.DownloadedBytesLimit > 0 {
+		args = append(args, fmt.Sprintf("--store.grpc.downloaded-bytes-limit=%d", *opts.DownloadedBytesLimit))
+	}
+
 	if opts.BlockConfigOptions != nil {
 		args = append(args, opts.BlockConfigOptions.toArgs()...)
 	}

--- a/website/content/docs/api-reference/api.md
+++ b/website/content/docs/api-reference/api.md
@@ -1417,6 +1417,7 @@ _Appears in:_
 | `storeLimitsOptions` _[StoreLimitsOptions](#storelimitsoptions)_ | StoreLimitsOptions allows configuration of the store API limits. |  | Optional: \{\} <br /> |
 | `indexHeaderConfig` _[IndexHeaderConfig](#indexheaderconfig)_ | IndexHeaderConfig allows configuration of the Store Gateway index header. |  | Optional: \{\} <br /> |
 | `blockConfig` _[BlockConfig](#blockconfig)_ | BlockConfig defines settings for block handling. |  | Optional: \{\} <br /> |
+| `downloadedBytesLimit` _integer_ | DownloadedBytesLimit is the maximum amount of downloaded (either fetched or touched) bytes<br />in a single Series/LabelNames/LabelValues gRPC call. The Series call fails if this limit is exceeded. | 0 | Optional: \{\} <br /> |
 | `paused` _boolean_ | When a resource is paused, no actions except for deletion<br />will be performed on the underlying objects. |  | Optional: \{\} <br /> |
 | `additionalArgs` _string array_ | Additional arguments to pass to the Thanos components.<br />An additional argument will override an existing argument provided by the operator if there is a conflict. |  | Optional: \{\} <br /> |
 | `additionalContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#container-v1-core) array_ | Additional containers to add to the Thanos components. |  | Optional: \{\} <br /> |


### PR DESCRIPTION
This commit adds an option for setting store downloaded bytes limit flags, so we can limit downloaded bytes on Store API gRPC calls