### PR TITLE
options: Fix automated mounting of configmaps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	dario.cat/mergo v1.0.2
 	github.com/go-logr/logr v1.4.3
 	github.com/golang/snappy v1.0.0
+	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus-community/prom-label-proxy v0.12.1
@@ -84,7 +85,6 @@ require (
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260115054156-294ebfa9ad83 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -499,6 +499,8 @@ func additionalToOpts(in v1alpha1.Additional) manifests.Additional {
 		Ports:        in.Ports,
 		Env:          in.Env,
 		ServicePorts: in.ServicePorts,
+		ConfigMaps:   in.ConfigMaps,
+		Secrets:      in.Secrets,
 	}
 }
 

--- a/internal/controller/transform_test.go
+++ b/internal/controller/transform_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func TestAdditionalToOpts(t *testing.T) {

--- a/internal/controller/transform_test.go
+++ b/internal/controller/transform_test.go
@@ -1,0 +1,109 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/thanos-community/thanos-operator/api/v1alpha1"
+	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestAdditionalToOpts(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    v1alpha1.Additional
+		expected manifests.Additional
+	}{
+		{
+			name:     "empty additional",
+			input:    v1alpha1.Additional{},
+			expected: manifests.Additional{},
+		},
+		{
+			name: "all fields populated",
+			input: v1alpha1.Additional{
+				Args: []string{"--test-arg=value"},
+				Containers: []corev1.Container{
+					{Name: "sidecar", Image: "sidecar:latest"},
+				},
+				Volumes: []corev1.Volume{
+					{Name: "test-volume"},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "test-mount", MountPath: "/test"},
+				},
+				Ports: []corev1.ContainerPort{
+					{Name: "metrics", ContainerPort: 8080},
+				},
+				Env: []corev1.EnvVar{
+					{Name: "TEST_ENV", Value: "test"},
+				},
+				ServicePorts: []corev1.ServicePort{
+					{Name: "http", Port: 8080},
+				},
+				ConfigMaps: []string{"my-configmap", "another-configmap"},
+				Secrets:    []string{"my-secret", "another-secret"},
+			},
+			expected: manifests.Additional{
+				Args: []string{"--test-arg=value"},
+				Containers: []corev1.Container{
+					{Name: "sidecar", Image: "sidecar:latest"},
+				},
+				Volumes: []corev1.Volume{
+					{Name: "test-volume"},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "test-mount", MountPath: "/test"},
+				},
+				Ports: []corev1.ContainerPort{
+					{Name: "metrics", ContainerPort: 8080},
+				},
+				Env: []corev1.EnvVar{
+					{Name: "TEST_ENV", Value: "test"},
+				},
+				ServicePorts: []corev1.ServicePort{
+					{Name: "http", Port: 8080},
+				},
+				ConfigMaps: []string{"my-configmap", "another-configmap"},
+				Secrets:    []string{"my-secret", "another-secret"},
+			},
+		},
+		{
+			name: "only configmaps and secrets",
+			input: v1alpha1.Additional{
+				ConfigMaps: []string{"config1", "config2"},
+				Secrets:    []string{"secret1"},
+			},
+			expected: manifests.Additional{
+				ConfigMaps: []string{"config1", "config2"},
+				Secrets:    []string{"secret1"},
+			},
+		},
+		{
+			name: "only args and containers",
+			input: v1alpha1.Additional{
+				Args: []string{"--arg1", "--arg2"},
+				Containers: []corev1.Container{
+					{Name: "test"},
+				},
+			},
+			expected: manifests.Additional{
+				Args: []string{"--arg1", "--arg2"},
+				Containers: []corev1.Container{
+					{Name: "test"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := additionalToOpts(tt.input)
+
+			if diff := cmp.Diff(tt.expected, result); diff != "" {
+				t.Errorf("additionalToOpts() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit ensures configmaps and secrets, from additional config are routed properly via transform to manifests.
Related to feature #553 