### PR TITLE
queryfrontend: enable service monitor for Thanos Query Frontend

### DIFF
--- a/internal/pkg/manifests/queryfrontend/builder.go
+++ b/internal/pkg/manifests/queryfrontend/builder.go
@@ -52,6 +52,9 @@ func (opts Options) Build() []client.Object {
 	objs = append(objs, newQueryFrontendDeployment(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newQueryFrontendService(opts, selectorLabels, objectMetaLabels))
 
+	if opts.ServiceMonitorConfig != nil {
+		objs = append(objs, manifests.BuildServiceMonitor(name, opts.Namespace, objectMetaLabels, selectorLabels, serviceMonitorOpts(opts.ServiceMonitorConfig)))
+	}
 	if opts.PodDisruptionConfig != nil {
 		objs = append(objs, manifests.NewPodDisruptionBudget(name, opts.Namespace, selectorLabels, objectMetaLabels, opts.Annotations, *opts.PodDisruptionConfig))
 	}
@@ -256,4 +259,11 @@ func (opts Options) GetSelectorLabels() map[string]string {
 // GetLabels returns a map of labels that can be used to look up qfe resources.
 func GetLabels(opts Options) map[string]string {
 	return manifests.MergeMaps(opts.Labels, opts.GetSelectorLabels())
+}
+
+func serviceMonitorOpts(from *manifests.ServiceMonitorConfig) manifests.ServiceMonitorOptions {
+	return manifests.ServiceMonitorOptions{
+		Port:     ptr.To(HTTPPortName),
+		Interval: from.Interval,
+	}
 }


### PR DESCRIPTION
fixes #604

This added a service monitor for the QueryFrontEnd when it is enabled.