### PR TITLE
Tune startup/liveness/readiness probes across components

### DIFF
--- a/internal/pkg/manifests/compact/builder.go
+++ b/internal/pkg/manifests/compact/builder.go
@@ -181,6 +181,18 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 									},
 								},
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/-/ready",
+										Port: intstr.FromInt32(HTTPPort),
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    2,
+								SuccessThreshold: 1,
+								FailureThreshold: 150,
+							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -188,11 +200,10 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-								InitialDelaySeconds: 20,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-								FailureThreshold:    15,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -201,11 +212,10 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-								InitialDelaySeconds: 60,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-								FailureThreshold:    8,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 							Env: envVars,
 							VolumeMounts: []corev1.VolumeMount{

--- a/internal/pkg/manifests/compact/testdata/statefulset-no-shard.golden.yaml
+++ b/internal/pkg/manifests/compact/testdata/statefulset-no-shard.golden.yaml
@@ -59,12 +59,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-compact
@@ -72,12 +71,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -87,6 +85,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/compact/testdata/statefulset-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/compact/testdata/statefulset-with-otel-sidecar.golden.yaml
@@ -66,12 +66,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-compact
@@ -79,12 +78,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -94,6 +92,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/compact/testdata/statefulset-with-shard.golden.yaml
+++ b/internal/pkg/manifests/compact/testdata/statefulset-with-shard.golden.yaml
@@ -59,12 +59,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-compact
@@ -72,12 +71,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -87,6 +85,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -149,11 +149,10 @@ func newQueryDeployment(opts Options, selectorLabels, objectMetaLabels map[strin
 					Scheme: corev1.URISchemeHTTP,
 				},
 			},
-			InitialDelaySeconds: 30,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       5,
-			SuccessThreshold:    1,
-			FailureThreshold:    20,
+			TimeoutSeconds:   1,
+			PeriodSeconds:    2,
+			SuccessThreshold: 1,
+			FailureThreshold: 30,
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -162,11 +161,10 @@ func newQueryDeployment(opts Options, selectorLabels, objectMetaLabels map[strin
 					Port: intstr.FromInt32(HTTPPort),
 				},
 			},
-			InitialDelaySeconds: 30,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       30,
-			SuccessThreshold:    1,
-			FailureThreshold:    4,
+			TimeoutSeconds:   1,
+			PeriodSeconds:    10,
+			SuccessThreshold: 1,
+			FailureThreshold: 3,
 		},
 		Ports: []corev1.ContainerPort{
 			{

--- a/internal/pkg/manifests/query/testdata/deployment-basic.golden.yaml
+++ b/internal/pkg/manifests/query/testdata/deployment-basic.golden.yaml
@@ -70,12 +70,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-query
@@ -85,13 +84,12 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/query/testdata/deployment-with-container.golden.yaml
+++ b/internal/pkg/manifests/query/testdata/deployment-with-container.golden.yaml
@@ -70,12 +70,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-query
@@ -85,13 +84,12 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/query/testdata/deployment-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/query/testdata/deployment-with-otel-sidecar.golden.yaml
@@ -77,12 +77,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-query
@@ -92,13 +91,12 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/query/testdata/deployment-with-volumemount.golden.yaml
+++ b/internal/pkg/manifests/query/testdata/deployment-with-volumemount.golden.yaml
@@ -70,12 +70,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-query
@@ -85,13 +84,12 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/query/testdata/query-basic.golden.yaml
+++ b/internal/pkg/manifests/query/testdata/query-basic.golden.yaml
@@ -85,12 +85,11 @@
           image: quay.io/thanos/thanos:v0.40.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            failureThreshold: 4
+            failureThreshold: 3
             httpGet:
               path: /-/healthy
               port: 9090
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           name: thanos-query
@@ -100,13 +99,12 @@
           - containerPort: 9090
             name: http
           readinessProbe:
-            failureThreshold: 20
+            failureThreshold: 30
             httpGet:
               path: /-/ready
               port: 9090
               scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 5
+            periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
           resources: {}

--- a/internal/pkg/manifests/query/testdata/query-complete.golden.yaml
+++ b/internal/pkg/manifests/query/testdata/query-complete.golden.yaml
@@ -87,12 +87,11 @@
           image: quay.io/thanos/thanos:v0.40.1
           imagePullPolicy: IfNotPresent
           livenessProbe:
-            failureThreshold: 4
+            failureThreshold: 3
             httpGet:
               path: /-/healthy
               port: 9090
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           name: thanos-query
@@ -102,13 +101,12 @@
           - containerPort: 9090
             name: http
           readinessProbe:
-            failureThreshold: 20
+            failureThreshold: 30
             httpGet:
               path: /-/ready
               port: 9090
               scheme: HTTP
-            initialDelaySeconds: 30
-            periodSeconds: 5
+            periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
           resources: {}

--- a/internal/pkg/manifests/queryfrontend/builder.go
+++ b/internal/pkg/manifests/queryfrontend/builder.go
@@ -143,6 +143,19 @@ func newQueryFrontendDeployment(opts Options, selectorLabels, objectMetaLabels m
 									},
 								},
 							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path:   "/-/ready",
+										Port:   intstr.FromInt32(HTTPPort),
+										Scheme: corev1.URISchemeHTTP,
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    2,
+								SuccessThreshold: 1,
+								FailureThreshold: 30,
+							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -150,14 +163,10 @@ func newQueryFrontendDeployment(opts Options, selectorLabels, objectMetaLabels m
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-							},
-							ReadinessProbe: &corev1.Probe{
-								ProbeHandler: corev1.ProbeHandler{
-									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/-/ready",
-										Port: intstr.FromInt32(HTTPPort),
-									},
-								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 						},
 					},

--- a/internal/pkg/manifests/queryfrontend/testdata/deployment-basic.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/deployment-basic.golden.yaml
@@ -52,18 +52,27 @@ spec:
         - --query-frontend.compress-responses
         image: some-custom-image:v0.42.0
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: thanos-query-frontend
         ports:
         - containerPort: 9090
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/queryfrontend/testdata/deployment-with-cache.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/deployment-with-cache.golden.yaml
@@ -60,18 +60,27 @@ spec:
               name: test-secret
         image: some-custom-image:v0.42.0
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: thanos-query-frontend
         ports:
         - containerPort: 9090
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/queryfrontend/testdata/deployment-with-container.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/deployment-with-container.golden.yaml
@@ -52,18 +52,27 @@ spec:
         - --query-frontend.compress-responses
         image: some-custom-image:v0.42.0
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: thanos-query-frontend
         ports:
         - containerPort: 9090
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/queryfrontend/testdata/deployment-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/deployment-with-otel-sidecar.golden.yaml
@@ -59,18 +59,27 @@ spec:
             insecure: true
         image: some-custom-image:v0.42.0
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: thanos-query-frontend
         ports:
         - containerPort: 9090
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/queryfrontend/testdata/deployment-with-volumemount.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/deployment-with-volumemount.golden.yaml
@@ -52,18 +52,27 @@ spec:
         - --query-frontend.compress-responses
         image: some-custom-image:v0.42.0
         livenessProbe:
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         name: thanos-query-frontend
         ports:
         - containerPort: 9090
           name: http
           protocol: TCP
         readinessProbe:
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         resources: {}
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/queryfrontend/testdata/queryfrontend-basic.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/queryfrontend-basic.golden.yaml
@@ -60,18 +60,27 @@
           - --query-frontend.compress-responses
           image: quay.io/thanos/thanos:v0.40.1
           livenessProbe:
+            failureThreshold: 3
             httpGet:
               path: /-/healthy
               port: 9090
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           name: thanos-query-frontend
           ports:
           - containerPort: 9090
             name: http
             protocol: TCP
           readinessProbe:
+            failureThreshold: 30
             httpGet:
               path: /-/ready
               port: 9090
+              scheme: HTTP
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/queryfrontend/testdata/queryfrontend-with-cache.golden.yaml
+++ b/internal/pkg/manifests/queryfrontend/testdata/queryfrontend-with-cache.golden.yaml
@@ -74,18 +74,27 @@
           - --query-frontend.compress-responses
           image: quay.io/thanos/thanos:v0.40.1
           livenessProbe:
+            failureThreshold: 3
             httpGet:
               path: /-/healthy
               port: 9090
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           name: thanos-query-frontend
           ports:
           - containerPort: 9090
             name: http
             protocol: TCP
           readinessProbe:
+            failureThreshold: 30
             httpGet:
               path: /-/ready
               port: 9090
+              scheme: HTTP
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 1
           resources: {}
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal/pkg/manifests/receive/builder.go
+++ b/internal/pkg/manifests/receive/builder.go
@@ -256,6 +256,18 @@ func newIngestorStatefulSet(opts IngesterOptions, selectorLabels, objectMetaLabe
 									},
 								},
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/-/ready",
+										Port: intstr.FromInt32(HTTPPort),
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    2,
+								SuccessThreshold: 1,
+								FailureThreshold: 150,
+							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -263,11 +275,10 @@ func newIngestorStatefulSet(opts IngesterOptions, selectorLabels, objectMetaLabe
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-								InitialDelaySeconds: 20,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-								FailureThreshold:    15,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -276,11 +287,10 @@ func newIngestorStatefulSet(opts IngesterOptions, selectorLabels, objectMetaLabe
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-								InitialDelaySeconds: 60,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-								FailureThreshold:    8,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 							Env: []corev1.EnvVar{
 								{
@@ -746,11 +756,10 @@ func buildThanosRouterContainer(opts RouterOptions) corev1.Container {
 					Port: intstr.FromInt32(HTTPPort),
 				},
 			},
-			InitialDelaySeconds: 5,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       30,
-			SuccessThreshold:    1,
-			FailureThreshold:    8,
+			TimeoutSeconds:   1,
+			PeriodSeconds:    2,
+			SuccessThreshold: 1,
+			FailureThreshold: 30,
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -759,11 +768,10 @@ func buildThanosRouterContainer(opts RouterOptions) corev1.Container {
 					Port: intstr.FromInt32(HTTPPort),
 				},
 			},
-			InitialDelaySeconds: 5,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       30,
-			SuccessThreshold:    1,
-			FailureThreshold:    8,
+			TimeoutSeconds:   1,
+			PeriodSeconds:    10,
+			SuccessThreshold: 1,
+			FailureThreshold: 3,
 		},
 		Env: []corev1.EnvVar{
 			{

--- a/internal/pkg/manifests/receive/testdata/ingester-statefulset-basic.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/ingester-statefulset-basic.golden.yaml
@@ -68,12 +68,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-ingester
@@ -87,12 +86,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -102,6 +100,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/receive/testdata/ingester-statefulset-with-container.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/ingester-statefulset-with-container.golden.yaml
@@ -68,12 +68,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-ingester
@@ -87,12 +86,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -102,6 +100,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/receive/testdata/ingester-statefulset-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/ingester-statefulset-with-otel-sidecar.golden.yaml
@@ -76,12 +76,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-ingester
@@ -95,12 +94,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -110,6 +108,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/receive/testdata/ingester-statefulset-with-volumemount.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/ingester-statefulset-with-volumemount.golden.yaml
@@ -68,12 +68,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-ingester
@@ -87,12 +86,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -102,6 +100,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/receive/testdata/router-complete.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-complete.golden.yaml
@@ -129,12 +129,11 @@
           image: quay.io/thanos/thanos:v0.40.1
           imagePullPolicy: Always
           livenessProbe:
-            failureThreshold: 8
+            failureThreshold: 3
             httpGet:
               path: /-/healthy
               port: 10902
-            initialDelaySeconds: 5
-            periodSeconds: 30
+            periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
           name: thanos-receive-router
@@ -148,12 +147,11 @@
           - containerPort: 19291
             name: remote-write
           readinessProbe:
-            failureThreshold: 8
+            failureThreshold: 30
             httpGet:
               path: /-/ready
               port: 10902
-            initialDelaySeconds: 5
-            periodSeconds: 30
+            periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 1
           resources: {}

--- a/internal/pkg/manifests/receive/testdata/router-deployment-basic.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-deployment-basic.golden.yaml
@@ -73,12 +73,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-router
@@ -92,12 +91,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 8
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/receive/testdata/router-deployment-with-container.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-deployment-with-container.golden.yaml
@@ -73,12 +73,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-router
@@ -92,12 +91,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 8
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/receive/testdata/router-deployment-with-kube-resource-sync.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-deployment-with-kube-resource-sync.golden.yaml
@@ -69,12 +69,11 @@ spec:
         image: quay.io/thanos/thanos:latest
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-router
@@ -88,12 +87,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 8
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/receive/testdata/router-deployment-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-deployment-with-otel-sidecar.golden.yaml
@@ -81,12 +81,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-router
@@ -100,12 +99,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 8
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/receive/testdata/router-deployment-with-volumemount.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-deployment-with-volumemount.golden.yaml
@@ -73,12 +73,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-router
@@ -92,12 +91,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 8
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/receive/testdata/router-deployment-without-kube-resource-sync.golden.yaml
+++ b/internal/pkg/manifests/receive/testdata/router-deployment-without-kube-resource-sync.golden.yaml
@@ -69,12 +69,11 @@ spec:
         image: quay.io/thanos/thanos:latest
         imagePullPolicy: Always
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-receive-router
@@ -88,12 +87,11 @@ spec:
         - containerPort: 19291
           name: remote-write
         readinessProbe:
-          failureThreshold: 8
+          failureThreshold: 30
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 5
-          periodSeconds: 30
+          periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}

--- a/internal/pkg/manifests/ruler/builder.go
+++ b/internal/pkg/manifests/ruler/builder.go
@@ -193,6 +193,19 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 				},
 			},
 		},
+		StartupProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/-/ready",
+					Port:   intstr.FromInt32(HTTPPort),
+					Scheme: corev1.URISchemeHTTP,
+				},
+			},
+			TimeoutSeconds:   1,
+			PeriodSeconds:    2,
+			SuccessThreshold: 1,
+			FailureThreshold: 150,
+		},
 		ReadinessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
@@ -201,11 +214,10 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 					Scheme: corev1.URISchemeHTTP,
 				},
 			},
-			InitialDelaySeconds: 30,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       5,
-			SuccessThreshold:    1,
-			FailureThreshold:    20,
+			TimeoutSeconds:   1,
+			PeriodSeconds:    5,
+			SuccessThreshold: 1,
+			FailureThreshold: 3,
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -214,11 +226,10 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 					Port: intstr.FromInt32(HTTPPort),
 				},
 			},
-			InitialDelaySeconds: 30,
-			TimeoutSeconds:      1,
-			PeriodSeconds:       30,
-			SuccessThreshold:    1,
-			FailureThreshold:    4,
+			TimeoutSeconds:   1,
+			PeriodSeconds:    10,
+			SuccessThreshold: 1,
+			FailureThreshold: 3,
 		},
 		Env: []corev1.EnvVar{
 			{

--- a/internal/pkg/manifests/ruler/testdata/statefulset-basic.golden.yaml
+++ b/internal/pkg/manifests/ruler/testdata/statefulset-basic.golden.yaml
@@ -82,12 +82,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-ruler
@@ -97,12 +96,11 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -113,6 +111,15 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/ruler/testdata/statefulset-with-config-reloader.golden.yaml
+++ b/internal/pkg/manifests/ruler/testdata/statefulset-with-config-reloader.golden.yaml
@@ -74,12 +74,11 @@ spec:
         image: thanos:v0.30.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-ruler
@@ -89,12 +88,11 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -105,6 +103,15 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/ruler/testdata/statefulset-with-container.golden.yaml
+++ b/internal/pkg/manifests/ruler/testdata/statefulset-with-container.golden.yaml
@@ -82,12 +82,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-ruler
@@ -97,12 +96,11 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -113,6 +111,15 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/ruler/testdata/statefulset-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/ruler/testdata/statefulset-with-otel-sidecar.golden.yaml
@@ -89,12 +89,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-ruler
@@ -104,12 +103,11 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -120,6 +118,15 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/ruler/testdata/statefulset-with-volumemount.golden.yaml
+++ b/internal/pkg/manifests/ruler/testdata/statefulset-with-volumemount.golden.yaml
@@ -82,12 +82,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-ruler
@@ -97,12 +96,11 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -113,6 +111,15 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/ruler/testdata/statefulset-without-rules.golden.yaml
+++ b/internal/pkg/manifests/ruler/testdata/statefulset-without-rules.golden.yaml
@@ -73,12 +73,11 @@ spec:
         image: thanos:v0.30.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 4
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-ruler
@@ -88,12 +87,11 @@ spec:
         - containerPort: 9090
           name: http
         readinessProbe:
-          failureThreshold: 20
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 9090
             scheme: HTTP
-          initialDelaySeconds: 30
           periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
@@ -104,6 +102,15 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -220,6 +220,18 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 									},
 								},
 							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/-/ready",
+										Port: intstr.FromInt32(HTTPPort),
+									},
+								},
+								TimeoutSeconds:   1,
+								PeriodSeconds:    2,
+								SuccessThreshold: 1,
+								FailureThreshold: 150,
+							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
@@ -227,11 +239,10 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-								InitialDelaySeconds: 20,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-								FailureThreshold:    15,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    5,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -240,11 +251,10 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 										Port: intstr.FromInt32(HTTPPort),
 									},
 								},
-								InitialDelaySeconds: 60,
-								TimeoutSeconds:      1,
-								PeriodSeconds:       30,
-								SuccessThreshold:    1,
-								FailureThreshold:    8,
+								TimeoutSeconds:   1,
+								PeriodSeconds:    10,
+								SuccessThreshold: 1,
+								FailureThreshold: 3,
 							},
 							Env: envVars,
 							VolumeMounts: []corev1.VolumeMount{

--- a/internal/pkg/manifests/store/testdata/statefulset-basic.golden.yaml
+++ b/internal/pkg/manifests/store/testdata/statefulset-basic.golden.yaml
@@ -61,12 +61,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-store
@@ -76,12 +75,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -91,6 +89,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/store/testdata/statefulset-with-container.golden.yaml
+++ b/internal/pkg/manifests/store/testdata/statefulset-with-container.golden.yaml
@@ -61,12 +61,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-store
@@ -76,12 +75,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -91,6 +89,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/store/testdata/statefulset-with-otel-sidecar.golden.yaml
+++ b/internal/pkg/manifests/store/testdata/statefulset-with-otel-sidecar.golden.yaml
@@ -69,12 +69,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-store
@@ -84,12 +83,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -99,6 +97,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:

--- a/internal/pkg/manifests/store/testdata/statefulset-with-volumemount.golden.yaml
+++ b/internal/pkg/manifests/store/testdata/statefulset-with-volumemount.golden.yaml
@@ -61,12 +61,11 @@ spec:
         image: some-custom-image:v0.42.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
-          failureThreshold: 8
+          failureThreshold: 3
           httpGet:
             path: /-/healthy
             port: 10902
-          initialDelaySeconds: 60
-          periodSeconds: 30
+          periodSeconds: 10
           successThreshold: 1
           timeoutSeconds: 1
         name: thanos-store
@@ -76,12 +75,11 @@ spec:
         - containerPort: 10902
           name: http
         readinessProbe:
-          failureThreshold: 15
+          failureThreshold: 3
           httpGet:
             path: /-/ready
             port: 10902
-          initialDelaySeconds: 20
-          periodSeconds: 30
+          periodSeconds: 5
           successThreshold: 1
           timeoutSeconds: 1
         resources: {}
@@ -91,6 +89,14 @@ spec:
             drop:
             - ALL
           runAsNonRoot: true
+        startupProbe:
+          failureThreshold: 150
+          httpGet:
+            path: /-/ready
+            port: 10902
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:


### PR DESCRIPTION
## What

Tune the liveness/readiness/startup probes across all components so pods reach ready quickly and don't sit behind long fixed initial delays.

I spotte this whilst debugging slow e2e tests. I think these are genuine bottlenecks in production. In summary this change moves components that are slow to start up (potentially) to a startup probe and drops the initial delay for all components. Stateless components can come up instantly now!

! Note: This just stripped 50% off of our e2e testing time in CI !

## Changes

Per component, drop the fixed `initialDelaySeconds` on liveness/readiness and add a startup probe so slow starts are covered by the startup probe instead of a blanket delay, while steady-state liveness/readiness stay aggressive:

- **query**: more aggressive probes, drop startup delay
- **query-frontend**: aggressive probes for fast startup
- **store**: drop probe initial delays, add startup probe
- **compact**: drop probe initial delays, add startup probe
- **receive**: drop probe initial delays, add ingester startup probe
- **ruler**: add startup probe, make readiness and liveness aggressive

Golden manifest fixtures are regenerated to match.

