### PR TITLE
featuregate: give each feature its own config struct

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -343,9 +343,9 @@ func main() {
 		commonMetrics.FeatureGatesInfo.WithLabelValues(featuregate.PrometheusRule).Set(1)
 	}
 	if featureGateConfig.KubeResourceSyncEnabled() {
-		featureGateConfig.KubeResourceSyncImage = defaultKubeResourceSyncImage
+		featureGateConfig.KubeResourceSync.Image = defaultKubeResourceSyncImage
 		if image, ok := os.LookupEnv("KUBE_RESOURCE_SYNC_IMAGE"); ok {
-			featureGateConfig.KubeResourceSyncImage = image
+			featureGateConfig.KubeResourceSync.Image = image
 		}
 		commonMetrics.FeatureGatesInfo.WithLabelValues(featuregate.KubeResourceSync).Set(1)
 	}

--- a/config/operator.go
+++ b/config/operator.go
@@ -273,7 +273,7 @@ type deploymentConfig struct {
 // resources that configure Prometheus to scrape metrics from Thanos components.
 func WithServiceMonitor() DeploymentOption {
 	return func(c *deploymentConfig) {
-		c.featureGate.EnableServiceMonitor = true
+		c.featureGate.ServiceMonitor = featuregate.Enabled()
 	}
 }
 
@@ -284,7 +284,7 @@ func WithServiceMonitor() DeploymentOption {
 // configures Thanos Ruler to evaluate these rules for alerting.
 func WithPrometheusRule() DeploymentOption {
 	return func(c *deploymentConfig) {
-		c.featureGate.EnablePrometheusRuleDiscovery = true
+		c.featureGate.PrometheusRule = featuregate.Enabled()
 	}
 }
 
@@ -295,7 +295,7 @@ func WithPrometheusRule() DeploymentOption {
 // restarts, improving the responsiveness of hashring configuration updates.
 func WithSync() DeploymentOption {
 	return func(c *deploymentConfig) {
-		c.featureGate.EnableKubeResourceSync = true
+		c.featureGate.KubeResourceSync = &featuregate.KubeResourceSyncConfig{FeatureConfig: featuregate.FeatureConfig{Enabled: true}}
 	}
 }
 
@@ -307,7 +307,7 @@ func WithSync() DeploymentOption {
 // installed in the cluster.
 func WithOtelSidecar() DeploymentOption {
 	return func(c *deploymentConfig) {
-		c.featureGate.EnableOtelSidecar = true
+		c.featureGate.OtelSidecar = featuregate.Enabled()
 	}
 }
 
@@ -318,7 +318,7 @@ func WithOtelSidecar() DeploymentOption {
 // orphan and recreate StatefulSets when necessary to apply storage changes.
 func WithVolumeResize() DeploymentOption {
 	return func(c *deploymentConfig) {
-		c.featureGate.EnableVolumeResize = true
+		c.featureGate.VolumeResize = featuregate.Enabled()
 	}
 }
 
@@ -340,15 +340,15 @@ func WithFeatures(features ...string) DeploymentOption {
 		for _, feature := range features {
 			switch feature {
 			case featuregate.ServiceMonitor:
-				c.featureGate.EnableServiceMonitor = true
+				c.featureGate.ServiceMonitor = featuregate.Enabled()
 			case featuregate.PrometheusRule:
-				c.featureGate.EnablePrometheusRuleDiscovery = true
+				c.featureGate.PrometheusRule = featuregate.Enabled()
 			case featuregate.OtelSidecar:
-				c.featureGate.EnableOtelSidecar = true
+				c.featureGate.OtelSidecar = featuregate.Enabled()
 			case featuregate.KubeResourceSync:
-				c.featureGate.EnableKubeResourceSync = true
+				c.featureGate.KubeResourceSync = &featuregate.KubeResourceSyncConfig{FeatureConfig: featuregate.FeatureConfig{Enabled: true}}
 			case featuregate.VolumeResize:
-				c.featureGate.EnableVolumeResize = true
+				c.featureGate.VolumeResize = featuregate.Enabled()
 			}
 		}
 	}
@@ -473,19 +473,19 @@ func ControllerManagerDeployment(opts ...DeploymentOption) *appsv1.Deployment {
 func buildManagerArgs(featureGate featuregate.Config) []string {
 	args := []string{"--leader-elect", "--metrics-secure", "--metrics-bind-address=:8443", "--health-probe-bind-address=:8081", "--log.format=logfmt", "--log.level=debug"}
 
-	if featureGate.EnableServiceMonitor {
+	if featureGate.ServiceMonitorEnabled() {
 		args = append(args, "--enable-feature="+featuregate.ServiceMonitor)
 	}
-	if featureGate.EnablePrometheusRuleDiscovery {
+	if featureGate.PrometheusRuleEnabled() {
 		args = append(args, "--enable-feature="+featuregate.PrometheusRule)
 	}
-	if featureGate.EnableKubeResourceSync {
+	if featureGate.KubeResourceSyncEnabled() {
 		args = append(args, "--enable-feature="+featuregate.KubeResourceSync)
 	}
-	if featureGate.EnableOtelSidecar {
+	if featureGate.OtelSidecarEnabled() {
 		args = append(args, "--enable-feature="+featuregate.OtelSidecar)
 	}
-	if featureGate.EnableVolumeResize {
+	if featureGate.VolumeResizeEnabled() {
 		args = append(args, "--enable-feature="+featuregate.VolumeResize)
 	}
 

--- a/internal/pkg/featuregate/features.go
+++ b/internal/pkg/featuregate/features.go
@@ -49,75 +49,107 @@ func IsValidFeature(feature string) bool {
 	return false
 }
 
+// FeatureConfig is the base configuration shared by all features.
+// Features that need extra settings embed this and add their own fields.
+type FeatureConfig struct {
+	// Enabled indicates whether the feature is turned on.
+	Enabled bool
+}
+
+// KubeResourceSyncConfig configures the kube-resource-sync feature.
+type KubeResourceSyncConfig struct {
+	FeatureConfig
+	// Image is the container image used for the kube-resource-sync sidecar.
+	Image string
+}
+
 // Config holds information about globally enabled features.
 // This represents the actual feature state used by controllers and manifest builders.
+// A nil pointer means the feature is not configured, which is treated as disabled.
 type Config struct {
-	// EnableServiceMonitor enables the management of ServiceMonitor objects.
-	EnableServiceMonitor bool
-	// EnablePrometheusRuleDiscovery enables the discovery of PrometheusRule objects.
-	EnablePrometheusRuleDiscovery bool
-	// EnableOtelSidecar enables OpenTelemetry collector sidecar injection.
-	EnableOtelSidecar bool
-	// EnableKubeResourceSync enables the kube-resource-sync sidecar container.
-	EnableKubeResourceSync bool
-	// KubeResourceSyncImage specifies the image to use for the kube-resource-sync sidecar.
-	KubeResourceSyncImage string
-	// EnableVolumeResize enables the volume resize controller.
-	EnableVolumeResize bool
+	// ServiceMonitor configures management of ServiceMonitor objects.
+	ServiceMonitor *FeatureConfig
+	// PrometheusRule configures discovery of PrometheusRule objects.
+	PrometheusRule *FeatureConfig
+	// OtelSidecar configures OpenTelemetry collector sidecar injection.
+	OtelSidecar *FeatureConfig
+	// KubeResourceSync configures the kube-resource-sync sidecar container.
+	KubeResourceSync *KubeResourceSyncConfig
+	// VolumeResize configures the volume resize controller.
+	VolumeResize *FeatureConfig
+}
+
+// Enabled returns a pointer to an enabled FeatureConfig.
+// It is a convenience helper for constructing a Config.
+func Enabled() *FeatureConfig {
+	return &FeatureConfig{Enabled: true}
 }
 
 // ServiceMonitorEnabled returns true if ServiceMonitor management is enabled.
 func (c Config) ServiceMonitorEnabled() bool {
-	return c.EnableServiceMonitor
+	return c.ServiceMonitor != nil && c.ServiceMonitor.Enabled
 }
 
 // PrometheusRuleEnabled returns true if PrometheusRule discovery is enabled.
 func (c Config) PrometheusRuleEnabled() bool {
-	return c.EnablePrometheusRuleDiscovery
+	return c.PrometheusRule != nil && c.PrometheusRule.Enabled
 }
 
 // OtelSidecarEnabled returns true if OpenTelemetry sidecar injection is enabled.
 func (c Config) OtelSidecarEnabled() bool {
-	return c.EnableOtelSidecar
+	return c.OtelSidecar != nil && c.OtelSidecar.Enabled
 }
 
 // KubeResourceSyncEnabled returns true if KubeResourceSync sidecar is enabled.
 func (c Config) KubeResourceSyncEnabled() bool {
-	return c.EnableKubeResourceSync
+	return c.KubeResourceSync != nil && c.KubeResourceSync.Enabled
 }
 
 // VolumeResizeEnabled returns true if volume resize controller is enabled.
 func (c Config) VolumeResizeEnabled() bool {
-	return c.EnableVolumeResize
+	return c.VolumeResize != nil && c.VolumeResize.Enabled
 }
 
 // GetKubeResourceSyncImage returns the image used for the kube-resource-sync sidecar.
 func (c Config) GetKubeResourceSyncImage() string {
-	return c.KubeResourceSyncImage
+	if c.KubeResourceSync == nil {
+		return ""
+	}
+	return c.KubeResourceSync.Image
 }
 
 // ToFeatureGate converts a Flag to a Config struct for use by controllers.
 func (f *Flag) ToFeatureGate() Config {
-	return Config{
-		EnableServiceMonitor:          f.EnablesServiceMonitor(),
-		EnablePrometheusRuleDiscovery: f.EnablesPrometheusRule(),
-		EnableOtelSidecar:             f.EnablesOtelSidecar(),
-		EnableKubeResourceSync:        f.EnablesKubeResourceSync(),
-		EnableVolumeResize:            f.EnablesVolumeResize(),
+	var c Config
+	if f.EnablesServiceMonitor() {
+		c.ServiceMonitor = Enabled()
 	}
+	if f.EnablesPrometheusRule() {
+		c.PrometheusRule = Enabled()
+	}
+	if f.EnablesOtelSidecar() {
+		c.OtelSidecar = Enabled()
+	}
+	if f.EnablesKubeResourceSync() {
+		c.KubeResourceSync = &KubeResourceSyncConfig{FeatureConfig: FeatureConfig{Enabled: true}}
+	}
+	if f.EnablesVolumeResize() {
+		c.VolumeResize = Enabled()
+	}
+	return c
 }
 
 // ToGVK returns the GroupVersionKind for all enabled features.
 func (c Config) ToGVK() []schema.GroupVersionKind {
 	var gvk []schema.GroupVersionKind
-	if !c.EnableServiceMonitor {
+	if !c.ServiceMonitorEnabled() {
 		gvk = append(gvk, schema.GroupVersionKind{
 			Group:   "monitoring.coreos.com",
 			Version: "v1",
 			Kind:    "ServiceMonitor",
 		})
 	}
-	if !c.EnablePrometheusRuleDiscovery {
+	if !c.PrometheusRuleEnabled() {
 		gvk = append(gvk, schema.GroupVersionKind{
 			Group:   "monitoring.coreos.com",
 			Version: "v1",

--- a/internal/pkg/featuregate/features_test.go
+++ b/internal/pkg/featuregate/features_test.go
@@ -78,12 +78,17 @@ func TestConfig_OtelSidecarEnabled(t *testing.T) {
 	}{
 		{
 			name:   "otel sidecar enabled",
-			config: Config{EnableOtelSidecar: true},
+			config: Config{OtelSidecar: Enabled()},
 			want:   true,
 		},
 		{
 			name:   "otel sidecar disabled",
-			config: Config{EnableOtelSidecar: false},
+			config: Config{OtelSidecar: &FeatureConfig{Enabled: false}},
+			want:   false,
+		},
+		{
+			name:   "otel sidecar unset",
+			config: Config{},
 			want:   false,
 		},
 	}
@@ -105,12 +110,17 @@ func TestConfig_VolumeResizeEnabled(t *testing.T) {
 	}{
 		{
 			name:   "volume resize enabled",
-			config: Config{EnableVolumeResize: true},
+			config: Config{VolumeResize: Enabled()},
 			want:   true,
 		},
 		{
 			name:   "volume resize disabled",
-			config: Config{EnableVolumeResize: false},
+			config: Config{VolumeResize: &FeatureConfig{Enabled: false}},
+			want:   false,
+		},
+		{
+			name:   "volume resize unset",
+			config: Config{},
 			want:   false,
 		},
 	}
@@ -133,21 +143,17 @@ func TestFlag_ToFeatureGate(t *testing.T) {
 		{
 			name:     "no features",
 			features: []string{},
-			want: Config{
-				EnableServiceMonitor:          false,
-				EnablePrometheusRuleDiscovery: false,
-				EnableOtelSidecar:             false,
-				EnableVolumeResize:            false,
-			},
+			want:     Config{},
 		},
 		{
 			name:     "all features enabled",
-			features: []string{ServiceMonitor, PrometheusRule, OtelSidecar, VolumeResize},
+			features: []string{ServiceMonitor, PrometheusRule, OtelSidecar, KubeResourceSync, VolumeResize},
 			want: Config{
-				EnableServiceMonitor:          true,
-				EnablePrometheusRuleDiscovery: true,
-				EnableOtelSidecar:             true,
-				EnableVolumeResize:            true,
+				ServiceMonitor:   Enabled(),
+				PrometheusRule:   Enabled(),
+				OtelSidecar:      Enabled(),
+				KubeResourceSync: &KubeResourceSyncConfig{FeatureConfig: FeatureConfig{Enabled: true}},
+				VolumeResize:     Enabled(),
 			},
 		},
 	}

--- a/test/integration/featuregates/kuberesourcesync/suite_test.go
+++ b/test/integration/featuregates/kuberesourcesync/suite_test.go
@@ -35,8 +35,10 @@ func TestKubeResourceSync(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env, ctx, cancel = suite.Setup(featuregate.Config{
-		EnableKubeResourceSync: true,
-		KubeResourceSyncImage:  kubeResourceSyncImage,
+		KubeResourceSync: &featuregate.KubeResourceSyncConfig{
+			FeatureConfig: featuregate.FeatureConfig{Enabled: true},
+			Image:         kubeResourceSyncImage,
+		},
 	})
 	k8sClient = env.Client
 	Expect(k8sClient).NotTo(BeNil())

--- a/test/integration/featuregates/otel/suite_test.go
+++ b/test/integration/featuregates/otel/suite_test.go
@@ -33,7 +33,7 @@ func TestOtelSidecar(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env, ctx, cancel = suite.Setup(featuregate.Config{EnableOtelSidecar: true})
+	env, ctx, cancel = suite.Setup(featuregate.Config{OtelSidecar: featuregate.Enabled()})
 	k8sClient = env.Client
 	Expect(k8sClient).NotTo(BeNil())
 })

--- a/test/integration/featuregates/prometheusrule/suite_test.go
+++ b/test/integration/featuregates/prometheusrule/suite_test.go
@@ -32,7 +32,7 @@ func TestPrometheusRuleGate(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env, ctx, cancel = suite.Setup(featuregate.Config{EnablePrometheusRuleDiscovery: true})
+	env, ctx, cancel = suite.Setup(featuregate.Config{PrometheusRule: featuregate.Enabled()})
 	k8sClient = env.Client
 	Expect(k8sClient).NotTo(BeNil())
 })

--- a/test/integration/featuregates/servicemonitor/suite_test.go
+++ b/test/integration/featuregates/servicemonitor/suite_test.go
@@ -31,7 +31,7 @@ func TestServiceMonitorGate(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env, ctx, cancel = suite.Setup(featuregate.Config{EnableServiceMonitor: true})
+	env, ctx, cancel = suite.Setup(featuregate.Config{ServiceMonitor: featuregate.Enabled()})
 	k8sClient = env.Client
 	Expect(k8sClient).NotTo(BeNil())
 })

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -113,24 +113,6 @@ func Run(cmd *exec.Cmd) ([]byte, error) {
 	return output, nil
 }
 
-// UninstallPrometheusOperator uninstalls the prometheus
-func UninstallPrometheusOperator() {
-	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
-	if _, err := Run(cmd); err != nil {
-		warnError(err)
-	}
-}
-
-// UninstallCertManager uninstalls the cert manager
-func UninstallCertManager() {
-	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
-	cmd := exec.Command("kubectl", "delete", "-f", url)
-	if _, err := Run(cmd); err != nil {
-		warnError(err)
-	}
-}
-
 // InstallCertManager installs the cert manager bundle.
 func InstallCertManager() error {
 	url := fmt.Sprintf(certmanagerURLTmpl, certmanagerVersion)
@@ -162,20 +144,6 @@ func LoadImageToKindClusterWithName(name string) error {
 	return err
 }
 
-// GetNonEmptyLines converts given command output string into individual objects
-// according to line breakers, and ignores the empty elements in it.
-func GetNonEmptyLines(output string) []string {
-	var res []string
-	elements := strings.SplitSeq(output, "\n")
-	for element := range elements {
-		if element != "" {
-			res = append(res, element)
-		}
-	}
-
-	return res
-}
-
 // GetProjectDir returns the repo root by walking up from the working directory
 // until it finds go.mod, so it resolves correctly no matter how deeply nested the
 // caller's package is (e.g. test/e2e/compact) rather than assuming a fixed suffix.
@@ -201,14 +169,6 @@ func InstallMinIO() error {
 	cmd := exec.Command("kubectl", "apply", "-f", minioTestData())
 	_, err := Run(cmd)
 	return err
-}
-
-// UninstallMinIO uninstalls the object store
-func UninstallMinIO() {
-	cmd := exec.Command("kubectl", "delete", "-f", minioTestData())
-	if _, err := Run(cmd); err != nil {
-		warnError(err)
-	}
 }
 
 func CreateMinioObjectStorageSecret() error {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -81,10 +81,6 @@ type PrometheusResponse struct {
 	} `json:"data"`
 }
 
-func warnError(err error) {
-	_, _ = fmt.Fprintf(GinkgoWriter, "warning: %v\n", err)
-}
-
 // InstallPrometheusOperator installs the prometheus Operator to be used to export the enabled metrics.
 func InstallPrometheusOperator() error {
 	url := fmt.Sprintf(prometheusOperatorURL, prometheusOperatorVersion)


### PR DESCRIPTION
## What

Reworks `featuregate.Config` so each feature gets its own config struct instead of a flat bag of `EnableX` bools.

- Adds a shared `FeatureConfig{ Enabled bool }` base. Features that need more (kube-resource-sync with its image) embed it and add fields (`KubeResourceSyncConfig`).
- `Config` now holds one pointer per feature (`*FeatureConfig` / `*KubeResourceSyncConfig`). A nil pointer means the feature isn't configured, treated as disabled.
- The old loose `KubeResourceSyncImage` field moves onto `KubeResourceSync.Image`.

## Why

Gives each feature a place to grow beyond a single `Enabled` bool, and models "not configured" honestly (nil) now that gates come from the repeatable `--enable-feature` flag.

## Compatibility

The accessor methods (`ServiceMonitorEnabled()`, `GetKubeResourceSyncImage()`, etc.) keep the same signatures and are now nil-safe, so consumers (`transform.go`, controllers) are unchanged. Construction goes through a new `Enabled()` helper; `ToFeatureGate()` allocates a pointer only per enabled feature.

## Test plan

- `go build ./...`
- `go vet ./internal/pkg/featuregate/... ./config/... ./cmd/... ./test/integration/featuregates/...`
- `go test ./internal/pkg/featuregate/... ./config/...`

Note: this branch also carries a small pre-existing commit removing unused test-util funcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)