### PR TITLE
handlers: treat missing CRD as nothing to clean up

### DIFF
--- a/internal/pkg/handlers/handlers.go
+++ b/internal/pkg/handlers/handlers.go
@@ -117,7 +117,7 @@ func (h *Handler) DeleteResource(ctx context.Context, objs []client.Object) int 
 
 		err := h.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if errors.IsNotFound(err) || meta.IsNoMatchError(err) {
 				continue
 			}
 
@@ -139,7 +139,7 @@ func (h *Handler) DeleteResource(ctx context.Context, objs []client.Object) int 
 // If the item does not exist, it does not return an error.
 func (h *handler) deleteResource(ctx context.Context, obj client.Object) error {
 	logger := loggerForObj(h.logger, obj)
-	if err := h.client.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
+	if err := h.client.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) && !meta.IsNoMatchError(err) {
 		logger.Error(err, fmt.Sprintf("failed to delete resource %s, name: %s",
 			obj.GetObjectKind().GroupVersionKind().GroupKind().String(),
 			obj.GetName(),


### PR DESCRIPTION
## What

In `DeleteResource`, treat `meta.IsNoMatchError` the same as `IsNotFound` on both the initial `Get` and the `Delete`.

## Why

`DeleteResource` only special-cased `IsNotFound`. When a resource's CRD isn't installed on the cluster (e.g. prometheus-operator isn't present, so `ServiceMonitor`/`PrometheusRule` kinds aren't served), the client's RESTMapper returns a `NoKindMatchError`, not a `NotFound`. That was counted as a hard error, so cleanup bumped the error count and the reconcile failed and requeued indefinitely.

This is reachable today: the feature-gate cleanup builds objects to delete based purely on gate state, without checking whether the CRD exists, so an operator running with the gate off and the CRD never installed hits this on every reconcile.

If the kind isn't served, there's nothing to delete, so we skip it like a NotFound.

## Test plan

- `go build ./...`
- `go vet ./internal/pkg/handlers/...`
- `go test ./internal/pkg/handlers/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)