### PR TITLE
Embed featuregate.Config in manifests.Options

### DIFF
--- a/internal/controller/transform.go
+++ b/internal/controller/transform.go
@@ -236,13 +236,6 @@ func receiverV1Alpha1ToRouterOptions(in receiverV1Alpha1ToRouterTransformInput) 
 		ExternalLabels:    router.ExternalLabels,
 	}
 
-	if in.FeatureGate.KubeResourceSyncEnabled() {
-		ropts.FeatureGateConfig = &manifestreceive.FeatureGateConfig{
-			KubeResourceSyncEnabled: in.FeatureGate.KubeResourceSyncEnabled(),
-			KubeResourceSyncImage:   in.FeatureGate.GetKubeResourceSyncImage(),
-		}
-	}
-
 	if router.ReplicationProtocol != nil {
 		ropts.ReplicationProtocol = string(*router.ReplicationProtocol)
 	}
@@ -463,9 +456,7 @@ func commonToOpts(
 		},
 		StatefulSet:     statefulSetToOpts(statefulSet),
 		SecurityContext: common.SecurityContext,
-		Features: manifests.Features{
-			EnableOtelSidecar: featureGate.OtelSidecarEnabled(),
-		},
+		Config:          featureGate,
 	}
 }
 

--- a/internal/pkg/manifests/compact/builder_test.go
+++ b/internal/pkg/manifests/compact/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
@@ -132,8 +133,8 @@ func TestNewStatefulSet(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-					Features: manifests.Features{
-						EnableOtelSidecar: true,
+					Config: featuregate.Config{
+						OtelSidecar: featuregate.Enabled(),
 					},
 				},
 			},

--- a/internal/pkg/manifests/options.go
+++ b/internal/pkg/manifests/options.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -119,8 +121,8 @@ type Options struct {
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// Default is set via kubebuilder in CommonFields with FSGroup=1001.
 	SecurityContext *corev1.PodSecurityContext
-	// Features holds feature flags for the component
-	Features Features
+	// Config holds the operator feature gate configuration shared by all components.
+	featuregate.Config
 }
 
 // Placement is a struct that holds the placement configuration for the component
@@ -129,10 +131,6 @@ type Placement struct {
 	Affinity                  *corev1.Affinity
 	Tolerations               []corev1.Toleration
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint
-}
-
-type Features struct {
-	EnableOtelSidecar bool
 }
 
 // ValidateAndSanitizeResourceName sanitizes the provided name to a valid DNS-1123 subdomain.
@@ -263,7 +261,7 @@ func AugmentWithOptions(obj client.Object, opts Options) {
 			o.Spec.Template.Spec.SecurityContext = opts.SecurityContext
 		}
 
-		if opts.Features.EnableOtelSidecar {
+		if opts.OtelSidecarEnabled() {
 			augmentOtel(&o.Spec.Template)
 		}
 
@@ -299,7 +297,7 @@ func AugmentWithOptions(obj client.Object, opts Options) {
 			o.Spec.Template.Spec.SecurityContext = opts.SecurityContext
 		}
 
-		if opts.Features.EnableOtelSidecar {
+		if opts.OtelSidecarEnabled() {
 			augmentOtel(&o.Spec.Template)
 		}
 

--- a/internal/pkg/manifests/query/builder_test.go
+++ b/internal/pkg/manifests/query/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
@@ -176,8 +177,8 @@ func TestNewQueryDeployment(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-					Features: manifests.Features{
-						EnableOtelSidecar: true,
+					Config: featuregate.Config{
+						OtelSidecar: featuregate.Enabled(),
 					},
 				},
 				Timeout:       "15m",

--- a/internal/pkg/manifests/queryfrontend/builder_test.go
+++ b/internal/pkg/manifests/queryfrontend/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
@@ -231,8 +232,8 @@ func TestNewQueryFrontendDeployment(t *testing.T) {
 						"test": "annotation",
 					},
 					Replicas: 2,
-					Features: manifests.Features{
-						EnableOtelSidecar: true,
+					Config: featuregate.Config{
+						OtelSidecar: featuregate.Enabled(),
 					},
 				},
 				QueryService:         "thanos-query",

--- a/internal/pkg/manifests/receive/builder.go
+++ b/internal/pkg/manifests/receive/builder.go
@@ -77,11 +77,6 @@ type TenancyOpts struct {
 	TenantLabelName        string
 }
 
-type FeatureGateConfig struct {
-	KubeResourceSyncEnabled bool
-	KubeResourceSyncImage   string
-}
-
 // RouterOptions for Thanos Receive router
 type RouterOptions struct {
 	manifests.Options
@@ -89,7 +84,6 @@ type RouterOptions struct {
 	ExternalLabels      map[string]string
 	HashringConfig      string
 	ReplicationProtocol string
-	FeatureGateConfig   *FeatureGateConfig
 }
 
 // Build builds the ingester for Thanos Receive
@@ -141,7 +135,7 @@ func (opts RouterOptions) Build() []client.Object {
 	objs = append(objs, newRouterDeployment(opts, selectorLabels, objectMetaLabels))
 	objs = append(objs, newHashringConfigMap(name, opts.Namespace, opts.HashringConfig, objectMetaLabels))
 
-	if opts.FeatureGateConfig != nil && opts.FeatureGateConfig.KubeResourceSyncEnabled {
+	if opts.KubeResourceSyncEnabled() {
 		objs = append(objs, newRouterRole(name, opts.Namespace, objectMetaLabels))
 		objs = append(objs, newRouterRoleBinding(name, opts.Namespace, objectMetaLabels))
 	}
@@ -154,7 +148,7 @@ func (opts RouterOptions) Build() []client.Object {
 		objs = append(objs, manifests.BuildServiceMonitor(name, opts.Namespace, objectMetaLabels, selectorLabels, serviceMonitorOpts(opts.ServiceMonitorConfig)))
 
 		// Add separate ServiceMonitor for kube-resource-sync metrics when enabled
-		if opts.FeatureGateConfig != nil && opts.FeatureGateConfig.KubeResourceSyncEnabled {
+		if opts.KubeResourceSyncEnabled() {
 			kubeResourceSyncSMName := name + "-kube-resource-sync"
 			kubeResourceSyncSMOpts := manifests.ServiceMonitorOptions{
 				Port:     ptr.To("kube-resource-sync"),
@@ -394,7 +388,7 @@ func newRouterService(opts RouterOptions, selectorLabels, objectMetaLabels map[s
 	svc := newService(opts.GetGeneratedResourceName(), opts.Namespace, selectorLabels, objectMetaLabels, opts.Annotations)
 
 	// Add kube-resource-sync metrics port when enabled
-	if opts.FeatureGateConfig != nil && opts.FeatureGateConfig.KubeResourceSyncEnabled {
+	if opts.KubeResourceSyncEnabled() {
 		kubeResourceSyncPort := corev1.ServicePort{
 			Name:       "kube-resource-sync",
 			Port:       8080,
@@ -682,7 +676,7 @@ func serviceMonitorOpts(from *manifests.ServiceMonitorConfig) manifests.ServiceM
 
 // buildRouterVolumes builds the volumes for the router pod
 func buildRouterVolumes(opts RouterOptions, name string) []corev1.Volume {
-	if opts.FeatureGateConfig != nil && opts.FeatureGateConfig.KubeResourceSyncEnabled {
+	if opts.KubeResourceSyncEnabled() {
 		// When KubeResourceSync is enabled, use EmptyDir and let the sidecar sync from ConfigMap
 		return []corev1.Volume{
 			{
@@ -714,7 +708,7 @@ func buildRouterVolumes(opts RouterOptions, name string) []corev1.Volume {
 func buildRouterContainers(opts RouterOptions) []corev1.Container {
 	containers := []corev1.Container{buildThanosRouterContainer(opts)}
 
-	if opts.FeatureGateConfig != nil && opts.FeatureGateConfig.KubeResourceSyncEnabled {
+	if opts.KubeResourceSyncEnabled() {
 		containers = append(containers, buildKubeResourceSyncContainer(opts))
 	}
 
@@ -725,7 +719,7 @@ func buildRouterContainers(opts RouterOptions) []corev1.Container {
 func buildRouterInitContainers(opts RouterOptions) []corev1.Container {
 	var initContainers []corev1.Container
 
-	if opts.FeatureGateConfig != nil && opts.FeatureGateConfig.KubeResourceSyncEnabled {
+	if opts.KubeResourceSyncEnabled() {
 		initContainers = append(initContainers, buildKubeResourceSyncInitContainer(opts))
 	}
 
@@ -823,10 +817,7 @@ func buildThanosRouterContainer(opts RouterOptions) corev1.Container {
 
 // buildKubeResourceSyncContainer builds the kube-resource-sync sidecar container
 func buildKubeResourceSyncContainer(opts RouterOptions) corev1.Container {
-	var image string
-	if opts.FeatureGateConfig != nil {
-		image = opts.FeatureGateConfig.KubeResourceSyncImage
-	}
+	image := opts.GetKubeResourceSyncImage()
 
 	return corev1.Container{
 		Name:            kubeResourceSyncContainerName,

--- a/internal/pkg/manifests/receive/builder_test.go
+++ b/internal/pkg/manifests/receive/builder_test.go
@@ -3,6 +3,7 @@ package receive
 import (
 	"testing"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
@@ -191,8 +192,8 @@ func TestNewIngestorStatefulSet(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-					Features: manifests.Features{
-						EnableOtelSidecar: true,
+					Config: featuregate.Config{
+						OtelSidecar: featuregate.Enabled(),
 					},
 				},
 			},
@@ -308,8 +309,8 @@ func TestNewRouterDeployment(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-					Features: manifests.Features{
-						EnableOtelSidecar: true,
+					Config: featuregate.Config{
+						OtelSidecar: featuregate.Enabled(),
 					},
 				},
 			},
@@ -325,10 +326,12 @@ func TestNewRouterDeployment(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-				},
-				FeatureGateConfig: &FeatureGateConfig{
-					KubeResourceSyncEnabled: true,
-					KubeResourceSyncImage:   "quay.io/philipgough/kube-resource-sync:main",
+					Config: featuregate.Config{
+						KubeResourceSync: &featuregate.KubeResourceSyncConfig{
+							FeatureConfig: featuregate.FeatureConfig{Enabled: true},
+							Image:         "quay.io/philipgough/kube-resource-sync:main",
+						},
+					},
 				},
 			},
 		},
@@ -343,9 +346,6 @@ func TestNewRouterDeployment(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-				},
-				FeatureGateConfig: &FeatureGateConfig{
-					KubeResourceSyncEnabled: false,
 				},
 			},
 		},

--- a/internal/pkg/manifests/ruler/builder_test.go
+++ b/internal/pkg/manifests/ruler/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	manifestsstore "github.com/thanos-community/thanos-operator/internal/pkg/manifests/store"
 	"github.com/thanos-community/thanos-operator/test/utils"
@@ -267,8 +268,8 @@ func TestNewRulerStatefulSet(t *testing.T) {
 					Annotations: map[string]string{
 						"test": "annotation",
 					},
-					Features: manifests.Features{
-						EnableOtelSidecar: true,
+					Config: featuregate.Config{
+						OtelSidecar: featuregate.Enabled(),
 					},
 				},
 				Endpoints: []Endpoint{

--- a/internal/pkg/manifests/store/builder_test.go
+++ b/internal/pkg/manifests/store/builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
@@ -134,7 +135,7 @@ func TestNewStoreStatefulSet(t *testing.T) {
 			golden: "statefulset-with-otel-sidecar.golden.yaml",
 			opts: func() Options {
 				opts := buildDefaultOpts()
-				opts.Features.EnableOtelSidecar = true
+				opts.OtelSidecar = featuregate.Enabled()
 				return opts
 			},
 		},


### PR DESCRIPTION
Makes the feature gate config a shared common config on `manifests.Options` instead of projecting it into per-piece structs.

## What

- `manifests.Options` now embeds `featuregate.Config`. Since every component's options embed `manifests.Options`, the nil-safe gate accessors (`OtelSidecarEnabled()`, `KubeResourceSyncEnabled()`, `GetKubeResourceSyncImage()`) promote straight through, so builders read the gate directly.
- Dropped the `manifests.Features` struct and `receive.FeatureGateConfig` -- both were just projections of the same config.
- `commonToOpts` now sets the embedded config once for all controllers; removed the per-router `FeatureGateConfig` projection in the receive transform.

## Notes

No behavior change: the rendered manifests are identical (golden-file tests unchanged). No import cycle -- `featuregate` only depends on the k8s schema package.

Verified with `go build ./...`, `go vet ./internal/... ./cmd/...`, and `go test ./internal/pkg/manifests/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)