### PR TITLE
*: Fix reconcile status conditions

### DIFF
--- a/internal/controller/object_status_controller.go
+++ b/internal/controller/object_status_controller.go
@@ -45,9 +45,8 @@ import (
 
 // Define condition types and reasons
 const (
-	ConditionReconcileSuccess = "ReconcileSuccess"
-	ConditionReconcileFailed  = "ReconcileFailed"
-	ConditionPaused           = "Paused"
+	ConditionReady  = "Ready"
+	ConditionPaused = "Paused"
 
 	ReasonReconcileComplete = "ReconcileComplete"
 	ReasonReconcileError    = "ReconcileError"

--- a/internal/controller/thanoscompact_controller.go
+++ b/internal/controller/thanoscompact_controller.go
@@ -102,8 +102,8 @@ func (r *ThanosCompactReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.logger.Error(err, "failed to sync resources", "resource", compact.GetName(), "namespace", compact.GetNamespace())
 		r.recorder.Eventf(compact, nil, corev1.EventTypeWarning, "SyncFailed", "Reconcile", "Failed to sync resources: %v", err)
 		r.updateCondition(ctx, compact, metav1.Condition{
-			Type:    ConditionReconcileFailed,
-			Status:  metav1.ConditionTrue,
+			Type:    ConditionReady,
+			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcileError,
 			Message: err.Error(),
 		})
@@ -111,7 +111,7 @@ func (r *ThanosCompactReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	r.updateCondition(ctx, compact, metav1.Condition{
-		Type:    ConditionReconcileSuccess,
+		Type:    ConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcileComplete,
 		Message: "Reconciliation completed successfully",

--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -131,8 +131,8 @@ func (r *ThanosQueryReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.logger.Error(err, "failed to sync resources", "resource", query.GetName(), "namespace", query.GetNamespace())
 		r.recorder.Eventf(query, nil, corev1.EventTypeWarning, "SyncFailed", "Reconcile", "Failed to sync resources: %v", err)
 		r.updateCondition(ctx, query, metav1.Condition{
-			Type:    ConditionReconcileFailed,
-			Status:  metav1.ConditionTrue,
+			Type:    ConditionReady,
+			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcileError,
 			Message: err.Error(),
 		})
@@ -140,7 +140,7 @@ func (r *ThanosQueryReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	r.updateCondition(ctx, query, metav1.Condition{
-		Type:    ConditionReconcileSuccess,
+		Type:    ConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcileComplete,
 		Message: "Reconciliation completed successfully",

--- a/internal/controller/thanosreceive_controller.go
+++ b/internal/controller/thanosreceive_controller.go
@@ -138,8 +138,8 @@ func (r *ThanosReceiveReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		r.logger.Error(err, "failed to sync resources", "resource", receiver.GetName(), "namespace", receiver.GetNamespace())
 		r.recorder.Eventf(receiver, nil, corev1.EventTypeWarning, "SyncFailed", "Reconcile", "Failed to sync resources: %v", err)
 		r.updateCondition(ctx, receiver, metav1.Condition{
-			Type:    ConditionReconcileFailed,
-			Status:  metav1.ConditionTrue,
+			Type:    ConditionReady,
+			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcileError,
 			Message: err.Error(),
 		})
@@ -147,7 +147,7 @@ func (r *ThanosReceiveReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 
 	r.updateCondition(ctx, receiver, metav1.Condition{
-		Type:    ConditionReconcileSuccess,
+		Type:    ConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcileComplete,
 		Message: "Reconciliation completed successfully",

--- a/internal/controller/thanosruler_controller.go
+++ b/internal/controller/thanosruler_controller.go
@@ -161,8 +161,8 @@ func (r *ThanosRulerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.logger.Error(err, "failed to sync resources", "resource", ruler.GetName(), "namespace", ruler.GetNamespace())
 		r.recorder.Eventf(ruler, nil, corev1.EventTypeWarning, "SyncFailed", "Reconcile", "Failed to sync resources: %v", err)
 		r.updateCondition(ctx, ruler, metav1.Condition{
-			Type:    ConditionReconcileFailed,
-			Status:  metav1.ConditionTrue,
+			Type:    ConditionReady,
+			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcileError,
 			Message: err.Error(),
 		})
@@ -170,7 +170,7 @@ func (r *ThanosRulerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	r.updateCondition(ctx, ruler, metav1.Condition{
-		Type:    ConditionReconcileSuccess,
+		Type:    ConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcileComplete,
 		Message: "Reconciliation completed successfully",

--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -118,8 +118,8 @@ func (r *ThanosStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.logger.Error(err, "failed to sync resources", "resource", store.GetName(), "namespace", store.GetNamespace())
 		r.recorder.Eventf(store, nil, corev1.EventTypeWarning, "SyncFailed", "Reconcile", "Failed to sync resources: %v", err)
 		r.updateCondition(ctx, store, metav1.Condition{
-			Type:    ConditionReconcileFailed,
-			Status:  metav1.ConditionTrue,
+			Type:    ConditionReady,
+			Status:  metav1.ConditionFalse,
 			Reason:  ReasonReconcileError,
 			Message: err.Error(),
 		})
@@ -127,7 +127,7 @@ func (r *ThanosStoreReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	r.updateCondition(ctx, store, metav1.Condition{
-		Type:    ConditionReconcileSuccess,
+		Type:    ConditionReady,
 		Status:  metav1.ConditionTrue,
 		Reason:  ReasonReconcileComplete,
 		Message: "Reconciliation completed successfully",


### PR DESCRIPTION
Addresses https://github.com/thanos-community/thanos-operator/issues/635

Instead of two separate condition types for failed and success, we drop down to a single Ready type, as is kstatus convention.