### PR TITLE
Add namespace-scoped operators and isolate e2e suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,15 +213,10 @@ e2e-setup: install
 	@echo ">> building and loading operator image ${E2E_IMG}"
 	$(MAKE) docker-build IMG=${E2E_IMG}
 	KIND_CLUSTER=${KIND_CLUSTER} go run ./test/e2e/setup -image ${E2E_IMG}
-	@echo ">> deploying operator"
-	$(MAKE) deploy IMG_MAIN=${E2E_IMG}
-	@echo ">> waiting for operator to become available"
-	$(KUBECTL) wait --for=condition=Available deployment -l control-plane=controller-manager \
-		-n thanos-operator-system --timeout=300s
 
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
 test-e2e: e2e-setup
-	go test -timeout=15m ./test/e2e/... -ginkgo.v
+	E2E_IMG=${E2E_IMG} go test -timeout=15m ./test/e2e/... -ginkgo.v
 
 define require_clean_work_tree
 	@git update-index -q --ignore-submodules --refresh

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See the [feature gates guide](docs/guides/gated-features.md).
 
 ### Namespace Scoping
 
-Use `--watch-namespace` to run an operator for a single namespace. See the [namespace scoping guide](docs/guides/namespace-scoping.md) for deployment and per-suite test configuration.
+Use `--watch-namespace` to run an operator for a single namespace. See the [namespace scoping guide](docs/guides/namespace-scoping.md) for deployment and RBAC configuration.
 
 ## Contributing and development
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Usage of ./bin/manager:
     	The path to the client CA certificate file for mutual TLS authentication.
   -metrics-secure
     	If set the metrics endpoint is served securely
+  -watch-namespace string
+    	Namespace to watch. Empty watches all namespaces.
 ```
 
 CRDs supported by this operator are defined in [./config/crd/bases](./config/crd/bases/). Operator deployment manifests are defined in [./config/manager](./config/manager/). To edit and build configuration refer to [CRD docs](docs/api-reference/api.md).
@@ -105,6 +107,10 @@ Read more about getting started [here](docs/get-started.md) and how to [install]
 ### Feature Gates
 
 See the [feature gates guide](docs/guides/gated-features.md).
+
+### Namespace Scoping
+
+Use `--watch-namespace` to run an operator for a single namespace. See the [namespace scoping guide](docs/guides/namespace-scoping.md) for deployment and per-suite test configuration.
 
 ## Contributing and development
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -169,6 +169,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var watchNamespace string
 
 	var enabledFeatures featuregate.Flag
 	var featureGateConfigFile string
@@ -178,6 +179,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch. Empty watches all namespaces.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -222,6 +224,16 @@ func main() {
 		),
 	)
 	setupLog := ctrl.Log.WithName("setup")
+	cacheOptions, err := controller.CacheOptionsForNamespace(watchNamespace)
+	if err != nil {
+		setupLog.Error(err, "invalid namespace scope")
+		os.Exit(1)
+	}
+	if watchNamespace == "" {
+		setupLog.Info("watching all namespaces")
+	} else {
+		setupLog.Info("watching namespace", "namespace", watchNamespace)
+	}
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
 	// prevent from being vulnerable to the HTTP/2 Stream Cancelation and
@@ -297,6 +309,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
+		Cache:                  cacheOptions,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,

--- a/config/operator.go
+++ b/config/operator.go
@@ -263,7 +263,15 @@ type DeploymentOption func(*deploymentConfig)
 
 // deploymentConfig holds the configuration for the controller manager deployment.
 type deploymentConfig struct {
-	featureGate featuregate.Config
+	featureGate       featuregate.Config
+	watchOwnNamespace bool
+}
+
+// WithWatchOwnNamespace limits the operator to its deployment namespace.
+func WithWatchOwnNamespace() DeploymentOption {
+	return func(c *deploymentConfig) {
+		c.watchOwnNamespace = true
+	}
 }
 
 // WithServiceMonitor enables the service monitor feature.
@@ -466,6 +474,16 @@ func ControllerManagerDeployment(opts ...DeploymentOption) *appsv1.Deployment {
 		},
 	}
 
+	if config.watchOwnNamespace {
+		manager := &deployment.Spec.Template.Spec.Containers[0]
+		manager.Args = append(manager.Args, "--watch-namespace=$(POD_NAMESPACE)")
+		manager.Env = append(manager.Env, corev1.EnvVar{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"},
+			},
+		})
+	}
 	return deployment
 }
 

--- a/config/operator_test.go
+++ b/config/operator_test.go
@@ -19,6 +19,11 @@ func TestControllerManagerDeployment(t *testing.T) {
 			opts:   []DeploymentOption{},
 		},
 		{
+			name:   "deployment watching its own namespace",
+			golden: "deployment-watch-own-namespace.golden.yaml",
+			opts:   []DeploymentOption{WithWatchOwnNamespace()},
+		},
+		{
 			name:   "deployment with service monitor",
 			golden: "deployment-service-monitor.golden.yaml",
 			opts:   []DeploymentOption{WithServiceMonitor()},

--- a/config/testdata/deployment-watch-own-namespace.golden.yaml
+++ b/config/testdata/deployment-watch-own-namespace.golden.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: thanos-operator
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: thanos-operator
+    control-plane: controller-manager
+  name: controller-manager
+  namespace: system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --leader-elect
+        - --metrics-secure
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
+        - --log.format=logfmt
+        - --log.level=debug
+        - --watch-namespace=$(POD_NAMESPACE)
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: manager
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: controller-manager
+      terminationGracePeriodSeconds: 10
+status: {}

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -2,6 +2,8 @@
 
 Guides for operating Thanos Operator.
 
+- [Namespace Scoping](./namespace-scoping.md) - Run independent operators with per-namespace feature configuration.
+
 ## Feature Gates
 
 - **[Feature Gates](./gated-features.md)** - Comprehensive guide to all experimental features available in the Thanos Operator, including ServiceMonitor creation, PrometheusRule discovery, OpenTelemetry sidecar injection, and KubeResourceSync

--- a/docs/guides/namespace-scoping.md
+++ b/docs/guides/namespace-scoping.md
@@ -6,7 +6,9 @@ By default, Thanos Operator watches all namespaces. Use `--watch-namespace` to r
 ./thanos-operator --watch-namespace=monitoring
 ```
 
-The setting applies to component reconciliation, service discovery, status updates, and optional controllers such as volume resizing. It takes effect at startup; restart the operator to change it. An empty value preserves cluster-wide behavior.
+The setting limits which namespaces the operator watches and reconciles, including status updates and optional controllers such as volume resizing. It takes effect at startup; restart the operator to change it. An empty value preserves cluster-wide behavior.
+
+Service discovery already selects services in the owning resource's namespace, including when the operator watches all namespaces. This setting preserves that behavior.
 
 ## Watch the operator's own namespace
 

--- a/docs/guides/namespace-scoping.md
+++ b/docs/guides/namespace-scoping.md
@@ -1,0 +1,45 @@
+# Namespace Scoping
+
+By default, Thanos Operator watches all namespaces. Use `--watch-namespace` to restrict an instance to one namespace:
+
+```bash
+./thanos-operator --watch-namespace=monitoring
+```
+
+The setting applies to component reconciliation, service discovery, status updates, and optional controllers such as volume resizing. It takes effect at startup; restart the operator to change it. An empty value preserves cluster-wide behavior.
+
+## Watch the operator's own namespace
+
+Use the Downward API to pass the Deployment's namespace:
+
+```yaml
+env:
+  - name: POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+args:
+  - --watch-namespace=$(POD_NAMESPACE)
+```
+
+Add these entries to the manager container's existing environment and arguments. The Go deployment builder provides the same configuration through `config.WithWatchOwnNamespace()`.
+
+## Run multiple instances
+
+Deploy each operator in the namespace it manages and give the instances disjoint scopes. Each instance can enable its own [feature gates](./gated-features.md). A cluster-wide instance would also reconcile those namespaces, so stop or rescope it before introducing scoped instances.
+
+Leader-election leases remain in each operator's deployment namespace. Replicas in that namespace share a lease; operators deployed in separate namespaces elect their leaders independently.
+
+Watch scoping does not change installed RBAC. For namespaced workload permissions, bind the generated manager ClusterRole to the operator ServiceAccount using a RoleBinding in the managed namespace. Keep the separate leader-election RoleBinding in the deployment namespace. Secure operator metrics also require the existing cluster-scoped token-review and subject-access-review permissions.
+
+## End-to-end tests
+
+`make e2e-setup` installs shared dependencies and loads the operator image. Each suite then creates its own operator, ServiceAccount, and bindings in its test namespace. Features are disabled unless the suite passes them explicitly to `suite.Setup`.
+
+`make test-e2e` passes `E2E_IMG` to the suites. When running a suite directly after setup, pass the same image if you changed the default:
+
+```bash
+E2E_IMG=example.com/thanos-operator:v0.0.1 go test ./test/e2e/namespace -ginkgo.v
+```
+
+Use a dedicated test cluster. Setup rejects a running legacy test operator in `thanos-operator-system` because it would overlap with the per-suite operators.

--- a/docs/guides/namespace-scoping.md
+++ b/docs/guides/namespace-scoping.md
@@ -33,15 +33,3 @@ Deploy each operator in the namespace it manages and give the instances disjoint
 Leader-election leases remain in each operator's deployment namespace. Replicas in that namespace share a lease; operators deployed in separate namespaces elect their leaders independently.
 
 Watch scoping does not change installed RBAC. For namespaced workload permissions, bind the generated manager ClusterRole to the operator ServiceAccount using a RoleBinding in the managed namespace. Keep the separate leader-election RoleBinding in the deployment namespace. Secure operator metrics also require the existing cluster-scoped token-review and subject-access-review permissions.
-
-## End-to-end tests
-
-`make e2e-setup` installs shared dependencies and loads the operator image. Each suite then creates its own operator, ServiceAccount, and bindings in its test namespace. Features are disabled unless the suite passes them explicitly to `suite.Setup`.
-
-`make test-e2e` passes `E2E_IMG` to the suites. When running a suite directly after setup, pass the same image if you changed the default:
-
-```bash
-E2E_IMG=example.com/thanos-operator:v0.0.1 go test ./test/e2e/namespace -ginkgo.v
-```
-
-Use a dedicated test cluster.

--- a/docs/guides/namespace-scoping.md
+++ b/docs/guides/namespace-scoping.md
@@ -44,4 +44,4 @@ Watch scoping does not change installed RBAC. For namespaced workload permission
 E2E_IMG=example.com/thanos-operator:v0.0.1 go test ./test/e2e/namespace -ginkgo.v
 ```
 
-Use a dedicated test cluster. Setup rejects a running legacy test operator in `thanos-operator-system` because it would overlap with the per-suite operators.
+Use a dedicated test cluster.

--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -1,13 +1,29 @@
 package controller
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 
 	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/metrics"
 )
+
+// CacheOptionsForNamespace limits namespaced watches and reads. Empty watches all namespaces.
+func CacheOptionsForNamespace(namespace string) (cache.Options, error) {
+	if namespace == "" {
+		return cache.Options{}, nil
+	}
+	if errs := validation.IsDNS1123Label(namespace); len(errs) > 0 {
+		return cache.Options{}, fmt.Errorf("invalid watch namespace %q: %s", namespace, strings.Join(errs, ", "))
+	}
+	return cache.Options{DefaultNamespaces: map[string]cache.Config{namespace: {}}}, nil
+}
 
 // Config holds the configuration for all controllers.
 type Config struct {

--- a/internal/controller/config_test.go
+++ b/internal/controller/config_test.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCacheOptionsForNamespace(t *testing.T) {
+	all, err := CacheOptionsForNamespace("")
+	assert.NilError(t, err)
+	assert.Assert(t, all.DefaultNamespaces == nil)
+
+	scoped, err := CacheOptionsForNamespace("thanos-monitoring")
+	assert.NilError(t, err)
+	assert.Equal(t, len(scoped.DefaultNamespaces), 1)
+	_, exists := scoped.DefaultNamespaces["thanos-monitoring"]
+	assert.Assert(t, exists)
+
+	for _, namespace := range []string{"Monitoring", "bad_namespace", "a,b", " ", "$(POD_NAMESPACE)", strings.Repeat("a", 64)} {
+		t.Run(namespace, func(t *testing.T) {
+			_, err := CacheOptionsForNamespace(namespace)
+			assert.ErrorContains(t, err, "invalid watch namespace")
+		})
+	}
+}

--- a/test/e2e/compact/suite_test.go
+++ b/test/e2e/compact/suite_test.go
@@ -35,10 +35,7 @@ import (
 
 const namespace = "e2e-compact"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestCompact(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -47,12 +44,6 @@ func TestCompact(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c = suite.Setup(namespace)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/core/core_test.go
+++ b/test/e2e/core/core_test.go
@@ -61,7 +61,7 @@ var _ = Describe("core", Ordered, func() {
 				deployments := &appsv1.DeploymentList{}
 				if err := c.List(context.Background(), deployments,
 					client.MatchingLabels{"control-plane": "controller-manager"},
-					client.InNamespace(operatorNamespace)); err != nil {
+					client.InNamespace(namespace)); err != nil {
 					return err
 				}
 				if len(deployments.Items) != 1 {

--- a/test/e2e/core/suite_test.go
+++ b/test/e2e/core/suite_test.go
@@ -18,7 +18,7 @@ limitations under the License.
 // heart of the e2e coverage: a remote-write lands in the receiver, a query reads it
 // back, and a ruler evaluates against it. These specs must run in order, so they live
 // in one binary rather than being split per area like the leaf feature suites. Like
-// those suites it creates its own throwaway namespace and tears it down in AfterSuite,
+// those suites it creates its own throwaway namespace and cleans it up after the suite,
 // alongside its own namespace-scoped operator. Shared dependencies are bootstrapped
 // once by `make e2e-setup`.
 package core
@@ -38,10 +38,7 @@ import (
 
 const namespace = "e2e-core"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestCore(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -50,12 +47,6 @@ func TestCore(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c = suite.Setup(namespace)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/core/suite_test.go
+++ b/test/e2e/core/suite_test.go
@@ -19,9 +19,8 @@ limitations under the License.
 // back, and a ruler evaluates against it. These specs must run in order, so they live
 // in one binary rather than being split per area like the leaf feature suites. Like
 // those suites it creates its own throwaway namespace and tears it down in AfterSuite,
-// so reruns are idempotent and nothing leaks into the shared operator namespace. The
-// cluster (operator, prometheus-operator, cert-manager, MinIO, test Prometheus) is
-// bootstrapped once by `make e2e-setup`.
+// alongside its own namespace-scoped operator. Shared dependencies are bootstrapped
+// once by `make e2e-setup`.
 package core
 
 import (
@@ -37,14 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-const (
-	// namespace is the dedicated, throwaway namespace this suite creates and tears
-	// down, so reruns are idempotent and nothing leaks into the shared operator ns.
-	namespace = "e2e-core"
-	// operatorNamespace is where `make e2e-setup` deploys the operator. The suite only
-	// reads the controller-manager deployment there; it never modifies it.
-	operatorNamespace = "thanos-operator-system"
-)
+const namespace = "e2e-core"
 
 var (
 	c        client.Client

--- a/test/e2e/namespace/namespace_test.go
+++ b/test/e2e/namespace/namespace_test.go
@@ -28,8 +28,9 @@ func TestNamespaceIsolation(t *testing.T) {
 var _ = Describe("Operators in separate namespaces", func() {
 	It("keeps feature configuration local and leaves unwatched resources alone", func() {
 		ctx := context.Background()
-		c, monitored, _ := suite.Setup("e2e-ns-monitored", featuregate.ServiceMonitor)
-		_, plain, _ := suite.Setup("e2e-ns-plain")
+		const monitored, plain = "e2e-ns-monitored", "e2e-ns-plain"
+		c := suite.Setup(monitored, featuregate.ServiceMonitor)
+		suite.Setup(plain)
 		outside := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-ns-unwatched"}}
 		Expect(c.Create(ctx, outside)).To(Succeed())
 		DeferCleanup(func() { Expect(c.Delete(ctx, outside)).To(Succeed()) })

--- a/test/e2e/namespace/namespace_test.go
+++ b/test/e2e/namespace/namespace_test.go
@@ -1,0 +1,63 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+
+	"github.com/thanos-community/thanos-operator/api/v1alpha1"
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
+	"github.com/thanos-community/thanos-operator/test/e2e/suite"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNamespaceIsolation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Namespace isolation E2E Suite")
+}
+
+var _ = Describe("Operators in separate namespaces", func() {
+	It("keeps feature configuration local and leaves unwatched resources alone", func() {
+		ctx := context.Background()
+		c, monitored, _ := suite.Setup("e2e-ns-monitored", featuregate.ServiceMonitor)
+		_, plain, _ := suite.Setup("e2e-ns-plain")
+		outside := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "e2e-ns-unwatched"}}
+		Expect(c.Create(ctx, outside)).To(Succeed())
+		DeferCleanup(func() { Expect(c.Delete(ctx, outside)).To(Succeed()) })
+
+		suite.NewQuery(c, monitored)
+		suite.NewQuery(c, plain)
+		unwatched := &v1alpha1.ThanosQuery{
+			ObjectMeta: metav1.ObjectMeta{Name: suite.QueryName, Namespace: outside.Name},
+			Spec:       v1alpha1.ThanosQuerySpec{Replicas: 1},
+		}
+		Expect(c.Create(ctx, unwatched)).To(Succeed())
+
+		Eventually(func() (int, error) {
+			monitors := &monitoringv1.ServiceMonitorList{}
+			err := c.List(ctx, monitors, client.InNamespace(monitored))
+			return len(monitors.Items), err
+		}, time.Minute, time.Second).Should(Equal(1))
+
+		Consistently(func(g Gomega) {
+			monitors := &monitoringv1.ServiceMonitorList{}
+			g.Expect(c.List(ctx, monitors, client.InNamespace(plain))).To(Succeed())
+			g.Expect(monitors.Items).To(BeEmpty())
+			deployments := &appsv1.DeploymentList{}
+			g.Expect(c.List(ctx, deployments, client.InNamespace(outside.Name))).To(Succeed())
+			g.Expect(deployments.Items).To(BeEmpty())
+			current := &v1alpha1.ThanosQuery{}
+			g.Expect(c.Get(ctx, client.ObjectKeyFromObject(unwatched), current)).To(Succeed())
+			g.Expect(current.Status).To(Equal(unwatched.Status))
+		}, 10*time.Second, time.Second).Should(Succeed())
+	})
+})

--- a/test/e2e/query/suite_test.go
+++ b/test/e2e/query/suite_test.go
@@ -38,10 +38,7 @@ import (
 
 const namespace = "e2e-query"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestQuery(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -50,12 +47,6 @@ func TestQuery(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c = suite.Setup(namespace)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/receive/capnproto/suite_test.go
+++ b/test/e2e/receive/capnproto/suite_test.go
@@ -38,10 +38,7 @@ import (
 
 const namespace = "e2e-receive-capnproto"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestCapnproto(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -50,12 +47,6 @@ func TestCapnproto(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c = suite.Setup(namespace)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/receive/kuberesourcesync/suite_test.go
+++ b/test/e2e/receive/kuberesourcesync/suite_test.go
@@ -38,10 +38,7 @@ import (
 
 const namespace = "e2e-receive-krs"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestKubeResourceSync(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -50,12 +47,6 @@ func TestKubeResourceSync(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace, featuregate.KubeResourceSync)
+	c = suite.Setup(namespace, featuregate.KubeResourceSync)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/receive/kuberesourcesync/suite_test.go
+++ b/test/e2e/receive/kuberesourcesync/suite_test.go
@@ -15,8 +15,7 @@ limitations under the License.
 */
 
 // Package kuberesourcesync runs the kube-resource-sync feature-gate e2e specs for the
-// receive router as its own test binary against the shared cluster bootstrapped by
-// `make e2e-setup` (which enables the feature on the operator). Unlike the envtest
+// receive router with its own operator enabling kube-resource-sync. Unlike the envtest
 // integration suite, which can only inspect the rendered Deployment, this exercises the
 // feature for real: the router pod must come up with the injected init container and
 // sidecar, and remote-write must route through the hashring the sidecar syncs into the
@@ -29,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/test/e2e/suite"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,7 +50,7 @@ func TestKubeResourceSync(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c, _, teardown = suite.Setup(namespace, featuregate.KubeResourceSync)
 	Expect(c).NotTo(BeNil())
 })
 

--- a/test/e2e/ruler/prometheusrule/suite_test.go
+++ b/test/e2e/ruler/prometheusrule/suite_test.go
@@ -15,8 +15,7 @@ limitations under the License.
 */
 
 // Package prometheusrule runs the PrometheusRule feature-gate e2e as its own test
-// binary against the shared cluster bootstrapped by `make e2e-setup` (the operator is
-// deployed with --enable-feature=prometheus-rule). It stands up its own query so the
+// binary with its own operator enabling prometheus-rule. It stands up its own query so the
 // ruler can reconcile, then proves a PrometheusRule-derived rule is wired into a real
 // ruler pod and evaluates end-to-end. It sits beside ruler/stateless under
 // test/e2e/ruler and runs in parallel with it.
@@ -28,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/test/e2e/suite"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +49,7 @@ func TestPrometheusRuleFeatureGate(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c, _, teardown = suite.Setup(namespace, featuregate.PrometheusRule)
 	Expect(c).NotTo(BeNil())
 })
 

--- a/test/e2e/ruler/prometheusrule/suite_test.go
+++ b/test/e2e/ruler/prometheusrule/suite_test.go
@@ -37,10 +37,7 @@ import (
 
 const namespace = "e2e-ruler-prometheusrule"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestPrometheusRuleFeatureGate(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -49,12 +46,6 @@ func TestPrometheusRuleFeatureGate(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace, featuregate.PrometheusRule)
+	c = suite.Setup(namespace, featuregate.PrometheusRule)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/ruler/stateless/stateless_test.go
+++ b/test/e2e/ruler/stateless/stateless_test.go
@@ -130,7 +130,6 @@ var _ = Describe("Thanos stateless ruler", Ordered, func() {
 		header := map[string]string{
 			"THANOS-TENANT": "stateless_tenant",
 		}
-		// Allow kubelet to project hashring updates without kube-resource-sync.
 		Eventually(func() error {
 			return utils.DoRemoteWriteRequest(c, utils.StatelessRemoteWriteRequest(), namespace, routerLabels, header, receive.RemoteWritePort)
 		}, time.Minute*3, time.Second*1).Should(Succeed())

--- a/test/e2e/ruler/stateless/stateless_test.go
+++ b/test/e2e/ruler/stateless/stateless_test.go
@@ -130,9 +130,10 @@ var _ = Describe("Thanos stateless ruler", Ordered, func() {
 		header := map[string]string{
 			"THANOS-TENANT": "stateless_tenant",
 		}
+		// Allow kubelet to project hashring updates without kube-resource-sync.
 		Eventually(func() error {
 			return utils.DoRemoteWriteRequest(c, utils.StatelessRemoteWriteRequest(), namespace, routerLabels, header, receive.RemoteWritePort)
-		}, time.Minute*1, time.Second*1).Should(Succeed())
+		}, time.Minute*3, time.Second*1).Should(Succeed())
 	})
 
 	It("should allow querying of evaluated rules", func() {

--- a/test/e2e/ruler/stateless/suite_test.go
+++ b/test/e2e/ruler/stateless/suite_test.go
@@ -38,10 +38,7 @@ import (
 
 const namespace = "e2e-ruler-stateless"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestStatelessRuler(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -50,12 +47,6 @@ func TestStatelessRuler(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c = suite.Setup(namespace)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/setup/main.go
+++ b/test/e2e/setup/main.go
@@ -18,8 +18,7 @@ limitations under the License.
 // prometheus-operator, cert-manager, MinIO + its object-storage secret, and the
 // test Prometheus. It runs once (via `make e2e-setup`) before the suites, so the
 // per-suite test binaries can run concurrently against one cluster without racing
-// on this shared setup. Operator image build/load and deploy are handled by the
-// make target around this command.
+// on this shared setup. Each suite deploys its own namespace-scoped operator.
 package main
 
 import (
@@ -27,11 +26,14 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
+	operatorconfig "github.com/thanos-community/thanos-operator/config"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -40,6 +42,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/yaml"
 )
 
 const operatorNamespace = "thanos-operator-system"
@@ -58,7 +62,7 @@ func run() error {
 
 	scheme := runtime.NewScheme()
 	for _, add := range []func(*runtime.Scheme) error{
-		corev1.AddToScheme, rbacv1.AddToScheme, monitoringv1.AddToScheme,
+		corev1.AddToScheme, appsv1.AddToScheme, rbacv1.AddToScheme, monitoringv1.AddToScheme,
 	} {
 		if err := add(scheme); err != nil {
 			return fmt.Errorf("building scheme: %w", err)
@@ -67,6 +71,12 @@ func run() error {
 	c, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
+	}
+	if err := checkLegacyOperator(c); err != nil {
+		return err
+	}
+	if err := installOperatorRoles(c); err != nil {
+		return fmt.Errorf("installing operator roles: %w", err)
 	}
 
 	log.Println(">> installing prometheus-operator")
@@ -97,6 +107,41 @@ func run() error {
 		log.Printf(">> loading operator image %s into kind", *image)
 		if err := utils.LoadImageToKindClusterWithName(*image); err != nil {
 			return fmt.Errorf("loading image into kind: %w", err)
+		}
+	}
+	return nil
+}
+
+func checkLegacyOperator(c client.Client) error {
+	deployments := &appsv1.DeploymentList{}
+	if err := c.List(context.Background(), deployments, client.InNamespace(operatorNamespace),
+		client.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
+		return err
+	}
+	for _, deployment := range deployments.Items {
+		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas > 0 {
+			return fmt.Errorf("remove the legacy test operator deployment %s/%s before running namespace-isolated suites", operatorNamespace, deployment.Name)
+		}
+	}
+	return nil
+}
+
+func installOperatorRoles(c client.Client) error {
+	content, err := os.ReadFile("config/rbac/role.yaml")
+	if err != nil {
+		return err
+	}
+	managerRole := &rbacv1.ClusterRole{}
+	if err := yaml.Unmarshal(content, managerRole); err != nil {
+		return err
+	}
+	for _, role := range []*rbacv1.ClusterRole{managerRole, operatorconfig.MetricsAuthClusterRole()} {
+		rules := role.DeepCopy().Rules
+		if _, err := controllerutil.CreateOrUpdate(context.Background(), c, role, func() error {
+			role.Rules = rules
+			return nil
+		}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/test/e2e/setup/main.go
+++ b/test/e2e/setup/main.go
@@ -33,7 +33,6 @@ import (
 	operatorconfig "github.com/thanos-community/thanos-operator/config"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,7 +61,7 @@ func run() error {
 
 	scheme := runtime.NewScheme()
 	for _, add := range []func(*runtime.Scheme) error{
-		corev1.AddToScheme, appsv1.AddToScheme, rbacv1.AddToScheme, monitoringv1.AddToScheme,
+		corev1.AddToScheme, rbacv1.AddToScheme, monitoringv1.AddToScheme,
 	} {
 		if err := add(scheme); err != nil {
 			return fmt.Errorf("building scheme: %w", err)
@@ -71,9 +70,6 @@ func run() error {
 	c, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("creating client: %w", err)
-	}
-	if err := checkLegacyOperator(c); err != nil {
-		return err
 	}
 	if err := installOperatorRoles(c); err != nil {
 		return fmt.Errorf("installing operator roles: %w", err)
@@ -107,20 +103,6 @@ func run() error {
 		log.Printf(">> loading operator image %s into kind", *image)
 		if err := utils.LoadImageToKindClusterWithName(*image); err != nil {
 			return fmt.Errorf("loading image into kind: %w", err)
-		}
-	}
-	return nil
-}
-
-func checkLegacyOperator(c client.Client) error {
-	deployments := &appsv1.DeploymentList{}
-	if err := c.List(context.Background(), deployments, client.InNamespace(operatorNamespace),
-		client.MatchingLabels{"control-plane": "controller-manager"}); err != nil {
-		return err
-	}
-	for _, deployment := range deployments.Items {
-		if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas > 0 {
-			return fmt.Errorf("remove the legacy test operator deployment %s/%s before running namespace-isolated suites", operatorNamespace, deployment.Name)
 		}
 	}
 	return nil

--- a/test/e2e/store/suite_test.go
+++ b/test/e2e/store/suite_test.go
@@ -39,10 +39,7 @@ import (
 
 const namespace = "e2e-store"
 
-var (
-	c        client.Client
-	teardown func()
-)
+var c client.Client
 
 func TestStore(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -51,12 +48,6 @@ func TestStore(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	c, _, teardown = suite.Setup(namespace)
+	c = suite.Setup(namespace)
 	Expect(c).NotTo(BeNil())
-})
-
-var _ = AfterSuite(func() {
-	if teardown != nil {
-		teardown()
-	}
 })

--- a/test/e2e/suite/operator.go
+++ b/test/e2e/suite/operator.go
@@ -1,0 +1,52 @@
+package suite
+
+import (
+	"os"
+
+	operatorconfig "github.com/thanos-community/thanos-operator/config"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func metricsAuthBindingName(namespace string) string {
+	return namespace + "-metrics-auth"
+}
+
+func operatorObjects(namespace string, features []string) []client.Object {
+	deployment := operatorconfig.ControllerManagerDeployment(
+		operatorconfig.WithWatchOwnNamespace(),
+		operatorconfig.WithFeatures(features...),
+	)
+	image := os.Getenv("E2E_IMG")
+	if image == "" {
+		image = "example.com/thanos-operator:v0.0.1"
+	}
+	deployment.Spec.Template.Spec.Containers[0].Image = image
+
+	leaderBinding := operatorconfig.LeaderElectionRoleBinding()
+	leaderBinding.Subjects[0].Namespace = namespace
+	objects := []client.Object{
+		operatorconfig.ManagerServiceAccount(),
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: "manager-rolebinding"},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     operatorconfig.ManagerRoleName,
+			},
+			Subjects: []rbacv1.Subject{{Kind: "ServiceAccount", Name: deployment.Spec.Template.Spec.ServiceAccountName, Namespace: namespace}},
+		},
+		operatorconfig.LeaderElectionRole(),
+		leaderBinding,
+		deployment,
+	}
+	for _, obj := range objects {
+		obj.SetNamespace(namespace)
+	}
+	metricsBinding := operatorconfig.MetricsAuthClusterRoleBinding()
+	metricsBinding.Name = metricsAuthBindingName(namespace)
+	metricsBinding.Subjects[0].Namespace = namespace
+	return append(objects, metricsBinding)
+}

--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -16,17 +16,18 @@ limitations under the License.
 
 // Package suite provides the shared bootstrap for the e2e suites. The expensive
 // one-time cluster setup (operator image, prometheus-operator, cert-manager,
-// MinIO, test Prometheus) is done once by `make e2e-setup` before the suites run;
-// each suite only calls Setup to get a client scoped to its own namespace against
-// that shared cluster. Splitting per area lets the suites run as parallel `go test`
-// binaries while ordering within a suite is preserved.
+// MinIO, test Prometheus) is done once by `make e2e-setup` before the suites run.
+// Each suite deploys an operator watching only its own namespace, with explicit
+// feature gates, so suites can run concurrently against the shared cluster.
 package suite
 
 import (
 	"context"
 	"os"
+	"sync"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 
 	"k8s.io/utils/ptr"
@@ -35,12 +36,14 @@ import (
 
 	"github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"github.com/thanos-community/thanos-operator/internal/controller"
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
 	"github.com/thanos-community/thanos-operator/test/utils"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	resourceapi "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,18 +74,32 @@ config:
     enable: false
 `
 
-// Setup builds a controller-runtime client, ensures the given namespace exists,
-// and creates the object-storage secret in it. It returns the client, the
-// namespace name, and a teardown func (deletes the namespace) intended to be
-// called from AfterSuite. The one-time cluster bootstrap is assumed to be already
-// in place via `make e2e-setup`.
-func Setup(namespace string) (client.Client, string, func()) {
+// Setup deploys a namespace-scoped operator and object-storage secret.
+// Features are disabled unless explicitly requested. Shared dependencies must
+// already be installed by make e2e-setup.
+func Setup(namespace string, features ...string) (client.Client, string, func()) {
 	c := NewClient()
 	ctx := context.Background()
+	for _, feature := range features {
+		gomega.Expect(featuregate.IsValidFeature(feature)).To(gomega.BeTrue(), "unknown feature %q", feature)
+	}
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 	err := c.Create(ctx, ns)
-	gomega.Expect(client.IgnoreAlreadyExists(err)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "remove the existing test namespace %s before rerunning", namespace)
+	var cleanup sync.Once
+	teardown := func() {
+		cleanup.Do(func() {
+			gomega.Expect(client.IgnoreNotFound(c.Delete(ctx, &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: metricsAuthBindingName(namespace)},
+			}))).To(gomega.Succeed())
+			gomega.Expect(client.IgnoreNotFound(c.Delete(ctx, ns))).To(gomega.Succeed())
+			gomega.Eventually(func() bool {
+				return apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(ns), &corev1.Namespace{}))
+			}, 3*time.Minute, time.Second).Should(gomega.BeTrue(), "test namespace must be deleted before it can be reused")
+		})
+	}
+	ginkgo.DeferCleanup(teardown)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: ObjStoreSecret, Namespace: namespace},
@@ -90,11 +107,14 @@ func Setup(namespace string) (client.Client, string, func()) {
 		Data:       map[string][]byte{ObjStoreSecretKey: []byte(objStoreConfig)},
 	}
 	err = c.Create(ctx, secret)
-	gomega.Expect(client.IgnoreAlreadyExists(err)).NotTo(gomega.HaveOccurred())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	teardown := func() {
-		_ = c.Delete(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})
+	for _, obj := range operatorObjects(namespace, features) {
+		gomega.Expect(c.Create(ctx, obj)).To(gomega.Succeed())
 	}
+	gomega.Eventually(func() bool {
+		return utils.VerifyDeploymentReplicasRunning(c, 1, "controller-manager", namespace)
+	}, 3*time.Minute, time.Second).Should(gomega.BeTrue(), "namespace-scoped operator must become ready")
 	return c, namespace, teardown
 }
 

--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -24,7 +24,6 @@ package suite
 import (
 	"context"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -77,7 +76,7 @@ config:
 // Setup deploys a namespace-scoped operator and object-storage secret.
 // Features are disabled unless explicitly requested. Shared dependencies must
 // already be installed by make e2e-setup.
-func Setup(namespace string, features ...string) (client.Client, string, func()) {
+func Setup(namespace string, features ...string) client.Client {
 	c := NewClient()
 	ctx := context.Background()
 	for _, feature := range features {
@@ -87,19 +86,15 @@ func Setup(namespace string, features ...string) (client.Client, string, func())
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 	err := c.Create(ctx, ns)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "remove the existing test namespace %s before rerunning", namespace)
-	var cleanup sync.Once
-	teardown := func() {
-		cleanup.Do(func() {
-			gomega.Expect(client.IgnoreNotFound(c.Delete(ctx, &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: metricsAuthBindingName(namespace)},
-			}))).To(gomega.Succeed())
-			gomega.Expect(client.IgnoreNotFound(c.Delete(ctx, ns))).To(gomega.Succeed())
-			gomega.Eventually(func() bool {
-				return apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(ns), &corev1.Namespace{}))
-			}, 3*time.Minute, time.Second).Should(gomega.BeTrue(), "test namespace must be deleted before it can be reused")
-		})
-	}
-	ginkgo.DeferCleanup(teardown)
+	ginkgo.DeferCleanup(func() {
+		gomega.Expect(client.IgnoreNotFound(c.Delete(ctx, &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: metricsAuthBindingName(namespace)},
+		}))).To(gomega.Succeed())
+		gomega.Expect(client.IgnoreNotFound(c.Delete(ctx, ns))).To(gomega.Succeed())
+		gomega.Eventually(func() bool {
+			return apierrors.IsNotFound(c.Get(ctx, client.ObjectKeyFromObject(ns), &corev1.Namespace{}))
+		}, 3*time.Minute, time.Second).Should(gomega.BeTrue(), "test namespace must be deleted before it can be reused")
+	})
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: ObjStoreSecret, Namespace: namespace},
@@ -115,7 +110,7 @@ func Setup(namespace string, features ...string) (client.Client, string, func())
 	gomega.Eventually(func() bool {
 		return utils.VerifyDeploymentReplicasRunning(c, 1, "controller-manager", namespace)
 	}, 3*time.Minute, time.Second).Should(gomega.BeTrue(), "namespace-scoped operator must become ready")
-	return c, namespace, teardown
+	return c
 }
 
 // ObjStoreConfig references the per-namespace object-storage secret Setup creates,

--- a/test/integration/namespace/namespace_test.go
+++ b/test/integration/namespace/namespace_test.go
@@ -64,6 +64,7 @@ func TestNamespaceIsolation(t *testing.T) {
 		startManager(t, env, namespaces[1], featuregate.Config{})
 		for i, namespace := range namespaces[:2] {
 			key := client.ObjectKey{Name: controller.QueryNameFromParent(queryName), Namespace: namespace}
+			// Verify existing namespace-local discovery still works with a scoped cache.
 			require.Eventually(t, func() bool {
 				deployment := &appsv1.Deployment{}
 				if env.Client.Get(ctx, key, deployment) != nil {

--- a/test/integration/namespace/namespace_test.go
+++ b/test/integration/namespace/namespace_test.go
@@ -1,0 +1,186 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/thanos-community/thanos-operator/api/v1alpha1"
+	"github.com/thanos-community/thanos-operator/internal/controller"
+	"github.com/thanos-community/thanos-operator/internal/pkg/featuregate"
+	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
+	"github.com/thanos-community/thanos-operator/internal/pkg/metrics"
+	"github.com/thanos-community/thanos-operator/test/integration/suite"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	controllerconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+const queryName = "shared-name"
+
+func TestNamespaceIsolation(t *testing.T) {
+	root := filepath.Join("..", "..", "..")
+	env, err := suite.Start("",
+		filepath.Join(root, "config", "crd", "bases"),
+		filepath.Join(root, "test", "integration", "configs", "service-monitor.yaml"),
+		filepath.Join(root, "test", "integration", "configs", "prometheus-rule.yaml"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, env.Stop()) })
+	ctx := context.Background()
+	namespaces := []string{"monitored", "plain", "unwatched"}
+	for _, namespace := range namespaces {
+		require.NoError(t, env.Client.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}))
+		require.NoError(t, env.Client.Create(ctx, newQuery(namespace)))
+		require.NoError(t, env.Client.Create(ctx, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "store-" + namespace, Namespace: namespace,
+				Labels: map[string]string{manifests.DefaultStoreAPILabel: manifests.DefaultStoreAPIValue, manifests.PartOfLabel: manifests.DefaultPartOfLabel},
+			},
+			Spec: corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "grpc", Port: 10901}}},
+		}))
+	}
+
+	t.Run("scoped managers", func(t *testing.T) {
+		startManager(t, env, namespaces[0], featuregate.Config{
+			ServiceMonitor: &featuregate.ServiceMonitorConfig{FeatureConfig: featuregate.FeatureConfig{Enabled: true}},
+		})
+		startManager(t, env, namespaces[1], featuregate.Config{})
+		for i, namespace := range namespaces[:2] {
+			key := client.ObjectKey{Name: controller.QueryNameFromParent(queryName), Namespace: namespace}
+			require.Eventually(t, func() bool {
+				deployment := &appsv1.Deployment{}
+				if env.Client.Get(ctx, key, deployment) != nil {
+					return false
+				}
+				args := deployment.Spec.Template.Spec.Containers[0].Args
+				for _, candidate := range namespaces {
+					endpoint := fmt.Sprintf("--endpoint=dnssrv+_grpc._tcp.store-%s.%s.svc", candidate, candidate)
+					if slices.Contains(args, endpoint) != (candidate == namespace) {
+						return false
+					}
+				}
+				return true
+			}, time.Minute, 100*time.Millisecond, "discovery must remain in %s", namespace)
+
+			// The status controller's unqualified Lists must obey the same scope.
+			ready := int32(i + 1)
+			deployment := &appsv1.Deployment{}
+			require.NoError(t, env.Client.Get(ctx, key, deployment))
+			deployment.Status = appsv1.DeploymentStatus{Replicas: ready, ReadyReplicas: ready, AvailableReplicas: ready}
+			require.NoError(t, env.Client.Status().Update(ctx, deployment))
+			require.Eventually(t, func() bool {
+				query := &v1alpha1.ThanosQuery{}
+				return env.Client.Get(ctx, client.ObjectKey{Name: queryName, Namespace: namespace}, query) == nil && query.Status.Querier.AvailableReplicas == ready
+			}, time.Minute, 100*time.Millisecond)
+		}
+
+		monitorKey := client.ObjectKey{Name: controller.QueryNameFromParent(queryName), Namespace: namespaces[0]}
+		require.Eventually(t, func() bool {
+			return env.Client.Get(ctx, monitorKey, &monitoringv1.ServiceMonitor{}) == nil
+		}, time.Minute, 100*time.Millisecond)
+
+		outside := &v1alpha1.ThanosQuery{}
+		outsideKey := client.ObjectKey{Name: queryName, Namespace: namespaces[2]}
+		require.NoError(t, env.Client.Get(ctx, outsideKey, outside))
+		require.Never(t, func() bool {
+			plainMonitor := client.ObjectKey{Name: monitorKey.Name, Namespace: namespaces[1]}
+			err := env.Client.Get(ctx, plainMonitor, &monitoringv1.ServiceMonitor{})
+			if !apierrors.IsNotFound(err) {
+				return true
+			}
+			deployments := &appsv1.DeploymentList{}
+			if env.Client.List(ctx, deployments, client.InNamespace(namespaces[2])) != nil || len(deployments.Items) != 0 {
+				return true
+			}
+			current := &v1alpha1.ThanosQuery{}
+			return env.Client.Get(ctx, outsideKey, current) != nil || current.ResourceVersion != outside.ResourceVersion
+		}, 3*time.Second, 100*time.Millisecond, "disabled features and unwatched resources must stay untouched")
+	})
+
+	t.Run("cluster-wide default", func(t *testing.T) {
+		startManager(t, env, "", featuregate.Config{})
+		for _, namespace := range namespaces {
+			query := &v1alpha1.ThanosQuery{}
+			key := client.ObjectKey{Name: queryName, Namespace: namespace}
+			require.NoError(t, env.Client.Get(ctx, key, query))
+			query.Spec.Replicas = 3
+			require.NoError(t, env.Client.Update(ctx, query))
+			require.Eventually(t, func() bool {
+				deployment := &appsv1.Deployment{}
+				err := env.Client.Get(ctx, client.ObjectKey{Name: controller.QueryNameFromParent(queryName), Namespace: namespace}, deployment)
+				return err == nil && ptr.Deref(deployment.Spec.Replicas, 0) == 3
+			}, time.Minute, 100*time.Millisecond)
+		}
+	})
+}
+
+func newQuery(namespace string) *v1alpha1.ThanosQuery {
+	return &v1alpha1.ThanosQuery{
+		ObjectMeta: metav1.ObjectMeta{Name: queryName, Namespace: namespace},
+		Spec:       v1alpha1.ThanosQuerySpec{Replicas: 1},
+	}
+}
+
+func startManager(t *testing.T, env *suite.Env, namespace string, gates featuregate.Config) {
+	t.Helper()
+	cacheOptions, err := controller.CacheOptionsForNamespace(namespace)
+	require.NoError(t, err)
+	mgr, err := ctrl.NewManager(env.Cfg, ctrl.Options{
+		Scheme:     env.Scheme,
+		Cache:      cacheOptions,
+		Metrics:    metricsserver.Options{BindAddress: "0"},
+		Controller: controllerconfig.Controller{SkipNameValidation: ptr.To(true)},
+	})
+	require.NoError(t, err)
+	registry := prometheus.NewRegistry()
+	conf := controller.Config{
+		FeatureGate: gates,
+		InstrumentationConfig: controller.InstrumentationConfig{
+			Logger:          logr.Discard(),
+			EventRecorder:   events.NewFakeRecorder(1000),
+			MetricsRegistry: registry,
+			CommonMetrics:   metrics.NewCommonMetrics(registry),
+		},
+	}
+	for _, setup := range []func(ctrl.Manager) error{
+		controller.NewThanosQueryReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
+		controller.NewThanosReceiveReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
+		controller.NewThanosStoreReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
+		controller.NewThanosCompactReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
+		controller.NewThanosRulerReconciler(conf, "reloader:test", mgr.GetClient(), env.Scheme).SetupWithManager,
+		controller.NewObjectStatusReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
+		controller.NewVolumeResizeReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
+	} {
+		require.NoError(t, setup(mgr))
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- mgr.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(15 * time.Second):
+			t.Error("manager did not stop")
+		}
+	})
+	require.True(t, mgr.GetCache().WaitForCacheSync(ctx))
+}

--- a/test/integration/namespace/namespace_test.go
+++ b/test/integration/namespace/namespace_test.go
@@ -56,6 +56,10 @@ func TestNamespaceIsolation(t *testing.T) {
 		}))
 	}
 
+	outside := &v1alpha1.ThanosQuery{}
+	outsideKey := client.ObjectKey{Name: queryName, Namespace: namespaces[2]}
+	require.NoError(t, env.Client.Get(ctx, outsideKey, outside))
+
 	t.Run("scoped managers", func(t *testing.T) {
 		startManager(t, env, namespaces[0], featuregate.Config{
 			ServiceMonitor: &featuregate.ServiceMonitorConfig{FeatureConfig: featuregate.FeatureConfig{Enabled: true}},
@@ -96,9 +100,6 @@ func TestNamespaceIsolation(t *testing.T) {
 			return env.Client.Get(ctx, monitorKey, &monitoringv1.ServiceMonitor{}) == nil
 		}, time.Minute, 100*time.Millisecond)
 
-		outside := &v1alpha1.ThanosQuery{}
-		outsideKey := client.ObjectKey{Name: queryName, Namespace: namespaces[2]}
-		require.NoError(t, env.Client.Get(ctx, outsideKey, outside))
 		require.Never(t, func() bool {
 			plainMonitor := client.ObjectKey{Name: monitorKey.Name, Namespace: namespaces[1]}
 			err := env.Client.Get(ctx, plainMonitor, &monitoringv1.ServiceMonitor{})

--- a/test/integration/namespace/namespace_test.go
+++ b/test/integration/namespace/namespace_test.go
@@ -39,7 +39,6 @@ func TestNamespaceIsolation(t *testing.T) {
 	env, err := suite.Start("",
 		filepath.Join(root, "config", "crd", "bases"),
 		filepath.Join(root, "test", "integration", "configs", "service-monitor.yaml"),
-		filepath.Join(root, "test", "integration", "configs", "prometheus-rule.yaml"),
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, env.Stop()) })
@@ -160,17 +159,10 @@ func startManager(t *testing.T, env *suite.Env, namespace string, gates featureg
 			CommonMetrics:   metrics.NewCommonMetrics(registry),
 		},
 	}
-	for _, setup := range []func(ctrl.Manager) error{
-		controller.NewThanosQueryReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
-		controller.NewThanosReceiveReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
-		controller.NewThanosStoreReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
-		controller.NewThanosCompactReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
-		controller.NewThanosRulerReconciler(conf, "reloader:test", mgr.GetClient(), env.Scheme).SetupWithManager,
-		controller.NewObjectStatusReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
-		controller.NewVolumeResizeReconciler(conf, mgr.GetClient(), env.Scheme).SetupWithManager,
-	} {
-		require.NoError(t, setup(mgr))
-	}
+	query := controller.NewThanosQueryReconciler(conf, mgr.GetClient(), env.Scheme)
+	require.NoError(t, query.SetupWithManager(mgr))
+	status := controller.NewObjectStatusReconciler(conf, mgr.GetClient(), env.Scheme)
+	require.NoError(t, status.SetupWithManager(mgr))
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
 	go func() { done <- mgr.Start(ctx) }()

--- a/website/content/docs/guides/_index.md
+++ b/website/content/docs/guides/_index.md
@@ -4,6 +4,8 @@ title: Guides
 
 Guides for operating Thanos Operator.
 
+- [Namespace Scoping](namespace-scoping.md/) - Run independent operators with per-namespace feature configuration.
+
 ## Feature Gates
 
 - **[Feature Gates](gated-features.md/)** - Comprehensive guide to all experimental features available in the Thanos Operator, including ServiceMonitor creation, PrometheusRule discovery, OpenTelemetry sidecar injection, and KubeResourceSync

--- a/website/content/docs/guides/namespace-scoping.md
+++ b/website/content/docs/guides/namespace-scoping.md
@@ -6,7 +6,9 @@ By default, Thanos Operator watches all namespaces. Use `--watch-namespace` to r
 ./thanos-operator --watch-namespace=monitoring
 ```
 
-The setting applies to component reconciliation, service discovery, status updates, and optional controllers such as volume resizing. It takes effect at startup; restart the operator to change it. An empty value preserves cluster-wide behavior.
+The setting limits which namespaces the operator watches and reconciles, including status updates and optional controllers such as volume resizing. It takes effect at startup; restart the operator to change it. An empty value preserves cluster-wide behavior.
+
+Service discovery already selects services in the owning resource's namespace, including when the operator watches all namespaces. This setting preserves that behavior.
 
 ## Watch the operator's own namespace
 

--- a/website/content/docs/guides/namespace-scoping.md
+++ b/website/content/docs/guides/namespace-scoping.md
@@ -33,15 +33,3 @@ Deploy each operator in the namespace it manages and give the instances disjoint
 Leader-election leases remain in each operator's deployment namespace. Replicas in that namespace share a lease; operators deployed in separate namespaces elect their leaders independently.
 
 Watch scoping does not change installed RBAC. For namespaced workload permissions, bind the generated manager ClusterRole to the operator ServiceAccount using a RoleBinding in the managed namespace. Keep the separate leader-election RoleBinding in the deployment namespace. Secure operator metrics also require the existing cluster-scoped token-review and subject-access-review permissions.
-
-## End-to-end tests
-
-`make e2e-setup` installs shared dependencies and loads the operator image. Each suite then creates its own operator, ServiceAccount, and bindings in its test namespace. Features are disabled unless the suite passes them explicitly to `suite.Setup`.
-
-`make test-e2e` passes `E2E_IMG` to the suites. When running a suite directly after setup, pass the same image if you changed the default:
-
-```bash
-E2E_IMG=example.com/thanos-operator:v0.0.1 go test ./test/e2e/namespace -ginkgo.v
-```
-
-Use a dedicated test cluster.

--- a/website/content/docs/guides/namespace-scoping.md
+++ b/website/content/docs/guides/namespace-scoping.md
@@ -44,4 +44,4 @@ Watch scoping does not change installed RBAC. For namespaced workload permission
 E2E_IMG=example.com/thanos-operator:v0.0.1 go test ./test/e2e/namespace -ginkgo.v
 ```
 
-Use a dedicated test cluster. Setup rejects a running legacy test operator in `thanos-operator-system` because it would overlap with the per-suite operators.
+Use a dedicated test cluster.

--- a/website/content/docs/guides/namespace-scoping.md
+++ b/website/content/docs/guides/namespace-scoping.md
@@ -1,0 +1,45 @@
+# Namespace Scoping
+
+By default, Thanos Operator watches all namespaces. Use `--watch-namespace` to restrict an instance to one namespace:
+
+```bash
+./thanos-operator --watch-namespace=monitoring
+```
+
+The setting applies to component reconciliation, service discovery, status updates, and optional controllers such as volume resizing. It takes effect at startup; restart the operator to change it. An empty value preserves cluster-wide behavior.
+
+## Watch the operator's own namespace
+
+Use the Downward API to pass the Deployment's namespace:
+
+```yaml
+env:
+  - name: POD_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+args:
+  - --watch-namespace=$(POD_NAMESPACE)
+```
+
+Add these entries to the manager container's existing environment and arguments. The Go deployment builder provides the same configuration through `config.WithWatchOwnNamespace()`.
+
+## Run multiple instances
+
+Deploy each operator in the namespace it manages and give the instances disjoint scopes. Each instance can enable its own [feature gates](../gated-features.md/). A cluster-wide instance would also reconcile those namespaces, so stop or rescope it before introducing scoped instances.
+
+Leader-election leases remain in each operator's deployment namespace. Replicas in that namespace share a lease; operators deployed in separate namespaces elect their leaders independently.
+
+Watch scoping does not change installed RBAC. For namespaced workload permissions, bind the generated manager ClusterRole to the operator ServiceAccount using a RoleBinding in the managed namespace. Keep the separate leader-election RoleBinding in the deployment namespace. Secure operator metrics also require the existing cluster-scoped token-review and subject-access-review permissions.
+
+## End-to-end tests
+
+`make e2e-setup` installs shared dependencies and loads the operator image. Each suite then creates its own operator, ServiceAccount, and bindings in its test namespace. Features are disabled unless the suite passes them explicitly to `suite.Setup`.
+
+`make test-e2e` passes `E2E_IMG` to the suites. When running a suite directly after setup, pass the same image if you changed the default:
+
+```bash
+E2E_IMG=example.com/thanos-operator:v0.0.1 go test ./test/e2e/namespace -ginkgo.v
+```
+
+Use a dedicated test cluster. Setup rejects a running legacy test operator in `thanos-operator-system` because it would overlap with the per-suite operators.


### PR DESCRIPTION
Thanos Operator currently watches every namespace, so separate instances cannot use different feature settings without reconciling each other's resources. Add `--watch-namespace` to scope all controller watches and cached reads to one namespace. Leaving it empty preserves cluster-wide behavior. The deployment builder can select its own namespace through the Downward API.

Each end-to-end suite now deploys its own scoped operator with explicit feature gates, namespace-local workload and leader-election bindings, and cleanup. Shared bootstrap installs dependencies and roles but no cluster-wide operator. This lets feature suites run alongside suites with those features disabled. The stateless-ruler remote-write assertion allows time for normal ConfigMap projection now that kube-resource-sync is disabled in that suite.

Integration and end-to-end coverage check two independently configured operators, scoped status updates, and untouched resources in an unwatched namespace. Discovery already selects services in the owning resource's namespace; integration coverage verifies that existing behavior works with a scoped cache, as well as checking the cluster-wide default. The namespace-scoping guide covers deployment, RBAC and overlapping scopes.

Validation:

- Unit and integration suites.
- End-to-end suites with Thanos v0.41.0 and v0.42.0 on Kind (Kubernetes v1.34.0).
- `make lint` and `make check-docs`, including build, generated manifests and chart checks.

Jira: [RHOBS-1746](https://redhat.atlassian.net/browse/RHOBS-1746)
