### PR TITLE
Remove redundant handler feature gates

### DIFF
--- a/internal/controller/object_status_controller.go
+++ b/internal/controller/object_status_controller.go
@@ -72,7 +72,7 @@ func NewObjectStatusReconciler(conf Config, client client.Client, scheme *runtim
 		Scheme:   scheme,
 		logger:   conf.InstrumentationConfig.Logger,
 		recorder: conf.InstrumentationConfig.EventRecorder,
-		handler:  handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger).SetFeatureGates(conf.FeatureGate.ToGVK()),
+		handler:  handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger),
 	}
 }
 

--- a/internal/controller/thanoscompact_controller.go
+++ b/internal/controller/thanoscompact_controller.go
@@ -129,7 +129,7 @@ func NewThanosCompactReconciler(conf Config, client client.Client, scheme *runti
 		metrics:     controllermetrics.NewThanosCompactMetrics(conf.InstrumentationConfig.MetricsRegistry, conf.InstrumentationConfig.CommonMetrics),
 		recorder:    conf.InstrumentationConfig.EventRecorder,
 		featureGate: conf.FeatureGate,
-		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger).SetFeatureGates(conf.FeatureGate.ToGVK()),
+		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger),
 	}
 
 	return reconciler

--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -79,7 +79,7 @@ func NewThanosQueryReconciler(conf Config, client client.Client, scheme *runtime
 		metrics:     controllermetrics.NewThanosQueryMetrics(conf.InstrumentationConfig.MetricsRegistry, conf.InstrumentationConfig.CommonMetrics),
 		recorder:    conf.InstrumentationConfig.EventRecorder,
 		featureGate: conf.FeatureGate,
-		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger).SetFeatureGates(conf.FeatureGate.ToGVK()),
+		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger),
 	}
 
 	return reconciler

--- a/internal/controller/thanosreceive_controller.go
+++ b/internal/controller/thanosreceive_controller.go
@@ -91,7 +91,7 @@ func NewThanosReceiveReconciler(conf Config, client client.Client, scheme *runti
 		metrics:     controllermetrics.NewThanosReceiveMetrics(conf.InstrumentationConfig.MetricsRegistry, conf.InstrumentationConfig.CommonMetrics),
 		recorder:    conf.InstrumentationConfig.EventRecorder,
 		featureGate: conf.FeatureGate,
-		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger).SetFeatureGates(conf.FeatureGate.ToGVK()),
+		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger),
 	}
 
 	return reconciler

--- a/internal/controller/thanosruler_controller.go
+++ b/internal/controller/thanosruler_controller.go
@@ -109,7 +109,7 @@ func NewThanosRulerReconciler(conf Config, configReloaderImage string, client cl
 		recorder:            conf.InstrumentationConfig.EventRecorder,
 		featureGate:         conf.FeatureGate,
 		configReloaderImage: configReloaderImage,
-		handler:             handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger).SetFeatureGates(conf.FeatureGate.ToGVK()),
+		handler:             handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger),
 	}
 
 	return reconciler
@@ -681,7 +681,7 @@ func (r *ThanosRulerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(configMapPredicate),
 		)
 
-	if !r.handler.IsFeatureGated(&monitoringv1.PrometheusRule{}) {
+	if r.featureGate.PrometheusRuleEnabled() {
 		bldr.Watches(
 			&monitoringv1.PrometheusRule{},
 			r.enqueueForPrometheusRule(),

--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -67,7 +67,7 @@ func NewThanosStoreReconciler(conf Config, client client.Client, scheme *runtime
 		metrics:     controllermetrics.NewThanosStoreMetrics(conf.InstrumentationConfig.MetricsRegistry, conf.InstrumentationConfig.CommonMetrics),
 		recorder:    conf.InstrumentationConfig.EventRecorder,
 		featureGate: conf.FeatureGate,
-		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger).SetFeatureGates(conf.FeatureGate.ToGVK()),
+		handler:     handlers.NewHandler(client, scheme, conf.InstrumentationConfig.Logger),
 	}
 
 	return reconciler

--- a/internal/pkg/featuregate/features.go
+++ b/internal/pkg/featuregate/features.go
@@ -1,10 +1,6 @@
 package featuregate
 
-import (
-	"slices"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-)
+import "slices"
 
 // Feature flag names for use with --enable-feature flag.
 // These follow Prometheus convention of kebab-case feature names.
@@ -145,24 +141,4 @@ func (f *Flag) ToFeatureGate() Config {
 		c.VolumeResize = Enabled()
 	}
 	return c
-}
-
-// ToGVK returns the GroupVersionKind for all enabled features.
-func (c Config) ToGVK() []schema.GroupVersionKind {
-	var gvk []schema.GroupVersionKind
-	if !c.ServiceMonitorEnabled() {
-		gvk = append(gvk, schema.GroupVersionKind{
-			Group:   "monitoring.coreos.com",
-			Version: "v1",
-			Kind:    "ServiceMonitor",
-		})
-	}
-	if !c.PrometheusRuleEnabled() {
-		gvk = append(gvk, schema.GroupVersionKind{
-			Group:   "monitoring.coreos.com",
-			Version: "v1",
-			Kind:    "PrometheusRule",
-		})
-	}
-	return gvk
 }

--- a/internal/pkg/handlers/handlers.go
+++ b/internal/pkg/handlers/handlers.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,8 +31,6 @@ type handler struct {
 	client client.Client
 	scheme *runtime.Scheme
 	logger logr.Logger
-
-	gatedGVK []schema.GroupVersionKind
 }
 
 // resourcePruner creates an object that prunes resources in the Kubernetes cluster.
@@ -53,12 +50,6 @@ func NewHandler(client client.Client, scheme *runtime.Scheme, logger logr.Logger
 	}
 }
 
-// SetFeatureGates sets the resource types skipped by CreateOrUpdate and DeleteResource.
-func (h *Handler) SetFeatureGates(gvk []schema.GroupVersionKind) *Handler {
-	h.gatedGVK = gvk
-	return h
-}
-
 // CreateOrUpdate creates or updates the given objects in the Kubernetes cluster.
 // It sets the owner reference of each object to the given owner.
 // It logs the operation and any errors encountered.
@@ -67,11 +58,6 @@ func (h *Handler) CreateOrUpdate(ctx context.Context, namespace string, owner cl
 	var errCount int
 	for _, obj := range objs {
 		logger := loggerForObj(h.logger, obj)
-		if h.IsFeatureGated(obj) {
-			logger.V(1).Info("resource is feature gated, skipping")
-			continue
-		}
-
 		if manifests.IsNamespacedResource(obj) {
 			obj.SetNamespace(namespace)
 			if err := ctrl.SetControllerReference(owner, obj, h.scheme); err != nil {
@@ -96,12 +82,6 @@ func (h *Handler) CreateOrUpdate(ctx context.Context, namespace string, owner cl
 	return errCount
 }
 
-// IsFeatureGated returns true if the given object is feature gated.
-func (h *handler) IsFeatureGated(obj client.Object) bool {
-	gvk := obj.GetObjectKind().GroupVersionKind()
-	return slices.Contains(h.gatedGVK, gvk)
-}
-
 // DeleteResource if they exist in the Kubernetes cluster.
 // It reads the item from the cache initially to see if it is present.
 // It issues a DELETE request to the Kubernetes API server if it exists.
@@ -109,11 +89,6 @@ func (h *Handler) DeleteResource(ctx context.Context, objs []client.Object) int 
 	var errCount int
 	for _, obj := range objs {
 		logger := loggerForObj(h.logger, obj)
-
-		if h.IsFeatureGated(obj) {
-			logger.V(1).Info("resource is feature gated, skipping")
-			continue
-		}
 
 		err := h.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 		if err != nil {
@@ -229,7 +204,7 @@ func (r *resourcePruner) Prune(ctx context.Context, keepResourceNames []string, 
 }
 
 // PruneByOwner deletes enabled resources controlled by owner in its namespace.
-// It ignores feature gates and returns the number of errors encountered.
+// It returns the number of errors encountered.
 func (r *resourcePruner) PruneByOwner(ctx context.Context, owner client.Object) int {
 	if owner.GetUID() == "" {
 		return 0

--- a/internal/pkg/handlers/handlers_test.go
+++ b/internal/pkg/handlers/handlers_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
 
@@ -261,9 +260,7 @@ func TestPruneByOwner(t *testing.T) {
 				Name: "owned-secret", Namespace: owner.Namespace, OwnerReferences: []metav1.OwnerReference{ownerRef},
 			}}
 			c := fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).WithObjects(unselected).Build()
-			h := NewHandler(c, testScheme, logr.Discard()).SetFeatureGates([]schema.GroupVersionKind{
-				tc.object.GetObjectKind().GroupVersionKind(),
-			})
+			h := NewHandler(c, testScheme, logr.Discard())
 
 			assert.Equal(t, tc.configure(h.NewResourcePruner()).PruneByOwner(ctx, owner), 0)
 			for i, obj := range objects {


### PR DESCRIPTION
Manifest builders and controller cleanup already check the feature configuration, so the handler's GVK-based feature gates are redundant. Remove `IsFeatureGated`, `SetFeatureGates`, `gatedGVK`, and `Config.ToGVK()`, along with their constructor wiring and test setup.

Use `PrometheusRuleEnabled()` directly when registering the ruler watch. The previous check received an object with an empty GVK, so it registered the watch even when PrometheusRule discovery was disabled.

Validation passed:

- `go test ./internal/... ./config/... ./cmd/...`
- PrometheusRule, ServiceMonitor, and ruler integration suites using envtest 1.34.1
- Formatting and `git diff --check`
