### PR TITLE
Use Go 1.26 pointer initialization in existing code

### DIFF
--- a/config/operator.go
+++ b/config/operator.go
@@ -170,7 +170,7 @@ func ControllerManagerServiceMonitor() *monitoringv1.ServiceMonitor {
 						HTTPConfigWithTLSFiles: monitoringv1.HTTPConfigWithTLSFiles{
 							TLSConfig: &monitoringv1.TLSConfig{
 								SafeTLSConfig: monitoringv1.SafeTLSConfig{
-									InsecureSkipVerify: ptr.To(true),
+									InsecureSkipVerify: new(true),
 								},
 							},
 						},
@@ -236,7 +236,7 @@ func AllowMetricsTrafficNetworkPolicy() *networkingv1.NetworkPolicy {
 					Ports: []networkingv1.NetworkPolicyPort{
 						{
 							Protocol: ptr.To(corev1.ProtocolTCP),
-							Port:     ptr.To(intstr.FromInt(8443)),
+							Port:     new(intstr.FromInt(8443)),
 						},
 					},
 				},

--- a/internal/controller/thanoscompact_controller.go
+++ b/internal/controller/thanoscompact_controller.go
@@ -31,12 +31,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -208,7 +206,7 @@ func (r *ThanosCompactReconciler) specToOptions(compact monitoringthanosiov1alph
 			CRD:         compact,
 			FeatureGate: r.featureGate,
 		})
-		opts.ShardName = ptr.To(shard.ShardName)
+		opts.ShardName = new(shard.ShardName)
 		opts.RelabelConfigs = relabelsConfigs
 		buildable = append(buildable, opts)
 	}
@@ -230,7 +228,7 @@ func (r *ThanosCompactReconciler) updateCondition(ctx context.Context, compact *
 	meta.SetStatusCondition(&conditions, condition)
 	compact.Status.Conditions = conditions
 	if condition.Type == ConditionPaused {
-		compact.Status.Paused = ptr.To(true)
+		compact.Status.Paused = new(true)
 	}
 
 	if err := r.Status().Update(ctx, compact); err != nil {

--- a/internal/controller/thanosquery_controller.go
+++ b/internal/controller/thanosquery_controller.go
@@ -45,8 +45,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -368,7 +366,7 @@ func (r *ThanosQueryReconciler) updateCondition(ctx context.Context, query *moni
 	meta.SetStatusCondition(&conditions, condition)
 	query.Status.Conditions = conditions
 	if condition.Type == ConditionPaused {
-		query.Status.Paused = ptr.To(true)
+		query.Status.Paused = new(true)
 	}
 	if err := r.Status().Update(ctx, query); err != nil {
 		r.logger.Error(err, "failed to update status for ThanosQuery", "name", query.Name)

--- a/internal/controller/thanosreceive_controller.go
+++ b/internal/controller/thanosreceive_controller.go
@@ -42,8 +42,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
-
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -440,7 +438,7 @@ func (r *ThanosReceiveReconciler) updateCondition(ctx context.Context, receiver 
 	meta.SetStatusCondition(&conditions, condition)
 	receiver.Status.Conditions = conditions
 	if condition.Type == ConditionPaused {
-		receiver.Status.Paused = ptr.To(true)
+		receiver.Status.Paused = new(true)
 	}
 	if err := r.Status().Update(ctx, receiver); err != nil {
 		r.logger.Error(err, "failed to update status for ThanosReceive", "name", receiver.Name)

--- a/internal/controller/thanosruler_controller.go
+++ b/internal/controller/thanosruler_controller.go
@@ -474,7 +474,7 @@ func (r *ThanosRulerReconciler) getRuleConfigMaps(ctx context.Context, ruler mon
 			if ruler.Spec.RuleTenancyConfig != nil {
 				tenantValueLabel := ruler.Spec.RuleTenancyConfig.TenantSpecifierLabel
 				if tenantValueLabel == nil {
-					tenantValueLabel = ptr.To(DefaultTenantSpecifier)
+					tenantValueLabel = new(DefaultTenantSpecifier)
 				}
 				tvl := *tenantValueLabel
 				value, exists := cfgmap.Labels[tvl]
@@ -580,7 +580,7 @@ func (r *ThanosRulerReconciler) getPrometheusRuleConfigMaps(ctx context.Context,
 		if ruler.Spec.RuleTenancyConfig != nil {
 			tenantValueLabel := ruler.Spec.RuleTenancyConfig.TenantSpecifierLabel
 			if tenantValueLabel == nil {
-				tenantValueLabel = ptr.To(DefaultTenantSpecifier)
+				tenantValueLabel = new(DefaultTenantSpecifier)
 			}
 			tvl := *tenantValueLabel
 			value, exists := rule.Labels[tvl]
@@ -887,7 +887,7 @@ func (r *ThanosRulerReconciler) processRuleGroupsWithTenancy(
 
 	tenantLabel := tenancyConfig.EnforcedTenantIdentifier
 	if tenantLabel == nil {
-		tenantLabel = ptr.To(defaultTenantIdentifier)
+		tenantLabel = new(defaultTenantIdentifier)
 	}
 	tl := *tenantLabel
 
@@ -952,7 +952,7 @@ func (r *ThanosRulerReconciler) createBucketedRuleConfigMaps(
 						Kind:       ruler.Kind,
 						Name:       ruler.Name,
 						UID:        ruler.UID,
-						Controller: ptr.To(true),
+						Controller: new(true),
 					},
 				},
 			},
@@ -968,7 +968,7 @@ func (r *ThanosRulerReconciler) createBucketedRuleConfigMaps(
 					Name: cmName,
 				},
 				Key:      key,
-				Optional: ptr.To(true),
+				Optional: new(true),
 			})
 		}
 	}
@@ -1059,7 +1059,7 @@ func (r *ThanosRulerReconciler) updateCondition(ctx context.Context, ruler *moni
 	meta.SetStatusCondition(&conditions, condition)
 	ruler.Status.Conditions = conditions
 	if condition.Type == ConditionPaused {
-		ruler.Status.Paused = ptr.To(true)
+		ruler.Status.Paused = new(true)
 	}
 	if err := r.Status().Update(ctx, ruler); err != nil {
 		r.logger.Error(err, "failed to update status for ThanosRuler", "name", ruler.Name)

--- a/internal/controller/thanosstore_controller.go
+++ b/internal/controller/thanosstore_controller.go
@@ -33,12 +33,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -205,7 +203,7 @@ func (r *ThanosStoreReconciler) specToOptions(store monitoringthanosiov1alpha1.T
 				Regex:       fmt.Sprintf("%d", i),
 			},
 		}
-		storeShardOpts.ShardIndex = ptr.To(i)
+		storeShardOpts.ShardIndex = new(i)
 		buildables[i] = storeShardOpts
 	}
 	return buildables
@@ -252,7 +250,7 @@ func (r *ThanosStoreReconciler) updateCondition(ctx context.Context, store *moni
 	meta.SetStatusCondition(&conditions, condition)
 	store.Status.Conditions = conditions
 	if condition.Type == ConditionPaused {
-		store.Status.Paused = ptr.To(true)
+		store.Status.Paused = new(true)
 	}
 	if err := r.Status().Update(ctx, store); err != nil {
 		r.logger.Error(err, "failed to update status for ThanosStore", "name", store.Name)

--- a/internal/pkg/manifests/compact/builder.go
+++ b/internal/pkg/manifests/compact/builder.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -130,7 +128,7 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 						Name: opts.ObjStoreSecret.Name,
 					},
 					Key:      opts.ObjStoreSecret.Key,
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		},
@@ -153,7 +151,7 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 				WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
 			},
 			ServiceName: name,
-			Replicas:    ptr.To(int32(1)),
+			Replicas:    new(int32(1)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
@@ -173,8 +171,8 @@ func newShardStatefulSet(opts Options, selectorLabels map[string]string, metaLab
 							// Ensure restrictive context for the container
 							// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								RunAsNonRoot:             ptr.To(true),
+								AllowPrivilegeEscalation: new(false),
+								RunAsNonRoot:             new(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",

--- a/internal/pkg/manifests/options.go
+++ b/internal/pkg/manifests/options.go
@@ -13,8 +13,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -216,11 +214,11 @@ func hashString(s string, length int) string {
 // ToFlags returns the flags for the Options
 func (o Options) ToFlags() []string {
 	if o.LogLevel == nil || *o.LogLevel == "" {
-		o.LogLevel = ptr.To(defaultLogLevel)
+		o.LogLevel = new(defaultLogLevel)
 	}
 
 	if o.LogFormat == nil || *o.LogFormat == "" {
-		o.LogFormat = ptr.To(defaultLogFormat)
+		o.LogFormat = new(defaultLogFormat)
 	}
 
 	return []string{
@@ -232,7 +230,7 @@ func (o Options) ToFlags() []string {
 // GetContainerImage for the Options
 func (o Options) GetContainerImage() string {
 	if o.Image == nil || *o.Image == "" {
-		o.Image = ptr.To(DefaultThanosImage)
+		o.Image = new(DefaultThanosImage)
 	}
 
 	// If the image already contains a tag (colon), return it as is
@@ -242,7 +240,7 @@ func (o Options) GetContainerImage() string {
 
 	// Otherwise, append the version
 	if o.Version == nil || *o.Version == "" {
-		o.Version = ptr.To(DefaultThanosVersion)
+		o.Version = new(DefaultThanosVersion)
 	}
 	return fmt.Sprintf("%s:%s", *o.Image, *o.Version)
 }
@@ -288,7 +286,7 @@ func AugmentWithOptions(obj client.Object, opts Options) {
 		}
 
 		o.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
-			FSGroup: ptr.To(DefaultFSGroup),
+			FSGroup: new(DefaultFSGroup),
 		}
 		if opts.SecurityContext != nil {
 			o.Spec.Template.Spec.SecurityContext = opts.SecurityContext

--- a/internal/pkg/manifests/query/builder.go
+++ b/internal/pkg/manifests/query/builder.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -133,8 +131,8 @@ func newQueryDeployment(opts Options, selectorLabels, objectMetaLabels map[strin
 		// Ensure restrictive context for the container
 		// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             ptr.To(true),
-			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsNonRoot:             new(true),
+			AllowPrivilegeEscalation: new(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{
 					"ALL",

--- a/internal/pkg/manifests/queryfrontend/builder.go
+++ b/internal/pkg/manifests/queryfrontend/builder.go
@@ -9,8 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -135,8 +133,8 @@ func newQueryFrontendDeployment(opts Options, selectorLabels, objectMetaLabels m
 							},
 							Env: env,
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								RunAsNonRoot:             ptr.To(true),
+								AllowPrivilegeEscalation: new(false),
+								RunAsNonRoot:             new(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",

--- a/internal/pkg/manifests/receive/builder.go
+++ b/internal/pkg/manifests/receive/builder.go
@@ -11,8 +11,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -217,7 +215,7 @@ func newIngestorStatefulSet(opts IngesterOptions, selectorLabels, objectMetaLabe
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: name,
-			Replicas:    ptr.To(opts.Replicas),
+			Replicas:    new(opts.Replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
@@ -237,8 +235,8 @@ func newIngestorStatefulSet(opts IngesterOptions, selectorLabels, objectMetaLabe
 							// Ensure restrictive context for the container
 							// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								RunAsNonRoot:             ptr.To(true),
+								AllowPrivilegeEscalation: new(false),
+								RunAsNonRoot:             new(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",
@@ -306,7 +304,7 @@ func newIngestorStatefulSet(opts IngesterOptions, selectorLabels, objectMetaLabe
 												Name: opts.ObjStoreSecret.Name,
 											},
 											Key:      opts.ObjStoreSecret.Key,
-											Optional: ptr.To(false),
+											Optional: new(false),
 										},
 									},
 								},
@@ -478,7 +476,7 @@ func newRouterDeployment(opts RouterOptions, selectorLabels, objectMetaLabels ma
 			Annotations: opts.Annotations,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: ptr.To(opts.Replicas),
+			Replicas: new(opts.Replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
@@ -494,17 +492,17 @@ func newRouterDeployment(opts RouterOptions, selectorLabels, objectMetaLabels ma
 					InitContainers:               initContainers,
 					Containers:                   containers,
 					ServiceAccountName:           name,
-					AutomountServiceAccountToken: ptr.To(true),
+					AutomountServiceAccountToken: new(true),
 				},
 			},
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
-					MaxSurge:       ptr.To(intstr.FromInt32(0)),
+					MaxUnavailable: new(intstr.FromInt32(1)),
+					MaxSurge:       new(intstr.FromInt32(0)),
 				},
 			},
-			RevisionHistoryLimit: ptr.To(int32(10)),
+			RevisionHistoryLimit: new(int32(10)),
 		},
 	}
 	manifests.AugmentWithOptions(deployment, opts.Options)
@@ -685,7 +683,7 @@ func buildRouterVolumes(opts RouterOptions, name string) []corev1.Volume {
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name,
 					},
-					DefaultMode: ptr.To(int32(420)),
+					DefaultMode: new(int32(420)),
 				},
 			},
 		},
@@ -723,8 +721,8 @@ func buildThanosRouterContainer(opts RouterOptions) corev1.Container {
 		// Ensure restrictive context for the container
 		// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             ptr.To(true),
-			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsNonRoot:             new(true),
+			AllowPrivilegeEscalation: new(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{
 					"ALL",
@@ -812,8 +810,8 @@ func buildKubeResourceSyncContainer(opts RouterOptions) corev1.Container {
 		Image:           image,
 		ImagePullPolicy: corev1.PullAlways,
 		SecurityContext: &corev1.SecurityContext{
-			RunAsNonRoot:             ptr.To(true),
-			AllowPrivilegeEscalation: ptr.To(false),
+			RunAsNonRoot:             new(true),
+			AllowPrivilegeEscalation: new(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 			},

--- a/internal/pkg/manifests/ruler/builder.go
+++ b/internal/pkg/manifests/ruler/builder.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/thanos-community/thanos-operator/internal/pkg/manifests"
@@ -184,8 +183,8 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 		// Ensure restrictive context for the container
 		// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
-			RunAsNonRoot:             ptr.To(true),
+			AllowPrivilegeEscalation: new(false),
+			RunAsNonRoot:             new(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{
 					"ALL",
@@ -302,7 +301,7 @@ func newRulerStatefulSet(opts Options, selectorLabels, objectMetaLabels map[stri
 						Name: opts.ObjStoreSecret.Name,
 					},
 					Key:      opts.ObjStoreSecret.Key,
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		})
@@ -728,13 +727,13 @@ func buildConfigReloaderContainer(opts Options) corev1.Container {
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		// Don't enable runAsNonRoot for config-reloader, as it uses non-numeric user nobody.
 		SecurityContext: &corev1.SecurityContext{
-			AllowPrivilegeEscalation: ptr.To(false),
+			AllowPrivilegeEscalation: new(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{
 					"ALL",
 				},
 			},
-			ReadOnlyRootFilesystem: ptr.To(true),
+			ReadOnlyRootFilesystem: new(true),
 		},
 		Args:         args,
 		VolumeMounts: volumeMounts,

--- a/internal/pkg/manifests/store/builder.go
+++ b/internal/pkg/manifests/store/builder.go
@@ -10,8 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -141,7 +139,7 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 						Name: opts.ObjStoreSecret.Name,
 					},
 					Key:      opts.ObjStoreSecret.Key,
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		},
@@ -156,7 +154,7 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 						Name: opts.IndexCacheConfig.FromSecret.Name,
 					},
 					Key:      opts.IndexCacheConfig.FromSecret.Key,
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		}
@@ -172,7 +170,7 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 						Name: opts.CachingBucketConfig.FromSecret.Name,
 					},
 					Key:      opts.CachingBucketConfig.FromSecret.Key,
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		}
@@ -192,7 +190,7 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 		},
 		Spec: appsv1.StatefulSetSpec{
 			ServiceName: name,
-			Replicas:    ptr.To(opts.Replicas),
+			Replicas:    new(opts.Replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},
@@ -212,8 +210,8 @@ func newStoreShardStatefulSet(opts Options, selectorLabels, objectMetaLabels map
 							// Ensure restrictive context for the container
 							// More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr.To(false),
-								RunAsNonRoot:             ptr.To(true),
+								AllowPrivilegeEscalation: new(false),
+								RunAsNonRoot:             new(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{
 										"ALL",


### PR DESCRIPTION
Replace `ptr.To(...)` with Go 1.26's `new(expression)` syntax in existing operator configuration, controllers, and manifest builders, and remove unused imports. This keeps the same pointer values and behavior.

Validation: `go build ./...` passed.
